### PR TITLE
Changes in TimePickerDialog

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -978,13 +978,13 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
      * mLegalKeys represents the keys that can be typed to get to the node.
      * mChildren are the children that can be reached from this node.
      */
-    private class Node {
+    private static class Node {
         private int[] mLegalKeys;
         private ArrayList<Node> mChildren;
 
         public Node(int... legalKeys) {
             mLegalKeys = legalKeys;
-            mChildren = new ArrayList<Node>();
+            mChildren = new ArrayList<>();
         }
 
         public void addChild(Node child) {


### PR DESCRIPTION
Simplified one boolean logic.

The other change is rather impacting. The Node class was not static though it should be since there's no need for keeping a reference to the parent class (TimePickerDialog). In the worst case scenario this could lead to a Memory Leak.