### PR TITLE
remove substring(0,1) in MonthView.drawMonthDayLabels(Canvas) 

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/MonthView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/MonthView.java
@@ -469,7 +469,7 @@ public abstract class MonthView extends View {
             int x = (2 * i + 1) * dayWidthHalf + mEdgePadding;
             mDayLabelCalendar.set(Calendar.DAY_OF_WEEK, calendarDay);
             canvas.drawText(mDayLabelCalendar.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.SHORT,
-                    Locale.getDefault()).toUpperCase(Locale.getDefault()).substring(0,1), x, y,
+                    Locale.getDefault()).toUpperCase(Locale.getDefault()), x, y,
                     mMonthDayLabelPaint);
         }
     }


### PR DESCRIPTION
I tested some languanes ( chinese, italy, and indian) , and the label displays good enough that is got only  by  Calendar.SHORT. 
The Phone's OS : android 4.0
screen : 480 * 800
So I remove the substring(0, 1).