### PR TITLE
Functionality allowing individual days in calendar to be highlighted

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerController.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerController.java
@@ -32,6 +32,8 @@ public interface DatePickerController {
     void unregisterOnDateChangedListener(DatePickerDialog.OnDateChangedListener listener);
 
     MonthAdapter.CalendarDay getSelectedDay();
+    
+    int[][] getDaysToHighlight();
 
     int getFirstDayOfWeek();
 

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -53,7 +53,9 @@ import java.util.Locale;
  */
 public class DatePickerDialog extends DialogFragment implements
         OnClickListener, DatePickerController {
-
+        
+    public static int[][] highlightedDays;
+        
     private static final String TAG = "DatePickerDialog";
 
     private static final int UNINITIALIZED = -1;
@@ -149,8 +151,10 @@ public class DatePickerDialog extends DialogFragment implements
      */
     public static DatePickerDialog newInstance(OnDateSetListener callBack, int year,
             int monthOfYear,
-            int dayOfMonth) {
+            int dayOfMonth
+            int[][] daysToHighlight) {
         DatePickerDialog ret = new DatePickerDialog();
+        highlightedDays = daysToHighlight;
         ret.initialize(callBack, year, monthOfYear, dayOfMonth);
         return ret;
     }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -152,7 +152,9 @@ public class DatePickerDialog extends DialogFragment implements
      * @param highlightedDays day/month/year array of days to highlight in calendar
      */
     public static DatePickerDialog newInstance(OnDateSetListener callBack, int year,
-            int monthOfYear, int dayOfMonth, int[][] highlightedDays) {
+            int monthOfYear, 
+            int dayOfMonth, 
+            int[][] highlightedDays) {
         daysToHighlight = highlightedDays;
         DatePickerDialog ret = new DatePickerDialog();
         ret.initialize(callBack, year, monthOfYear, dayOfMonth);

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -113,8 +113,8 @@ public class DatePickerDialog extends DialogFragment implements
     private String mYearPickerDescription;
     private String mSelectYear;
     
-    // array ndicating which days of the calendar to highlight
-    public static int[][] daysToHighlight;
+    // array indicating which dates of the calendar to highlight
+    private static int[][] daysToHighlight;
 
     /**
      * The callback used to indicate the user is done filling in the date.

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -53,9 +53,7 @@ import java.util.Locale;
  */
 public class DatePickerDialog extends DialogFragment implements
         OnClickListener, DatePickerController {
-        
-    public static int[][] highlightedDays;
-        
+
     private static final String TAG = "DatePickerDialog";
 
     private static final int UNINITIALIZED = -1;
@@ -114,6 +112,9 @@ public class DatePickerDialog extends DialogFragment implements
     private String mSelectDay;
     private String mYearPickerDescription;
     private String mSelectYear;
+    
+    // array ndicating which days of the calendar to highlight
+    public static int[][] daysToHighlight;
 
     /**
      * The callback used to indicate the user is done filling in the date.
@@ -148,13 +149,12 @@ public class DatePickerDialog extends DialogFragment implements
      * @param year The initial year of the dialog.
      * @param monthOfYear The initial month of the dialog.
      * @param dayOfMonth The initial day of the dialog.
+     * @param highlightedDays day/month/year array of days to highlight in calendar
      */
     public static DatePickerDialog newInstance(OnDateSetListener callBack, int year,
-            int monthOfYear,
-            int dayOfMonth
-            int[][] daysToHighlight) {
+            int monthOfYear, int dayOfMonth, int[][] highlightedDays) {
+        daysToHighlight = highlightedDays;
         DatePickerDialog ret = new DatePickerDialog();
-        highlightedDays = daysToHighlight;
         ret.initialize(callBack, year, monthOfYear, dayOfMonth);
         return ret;
     }
@@ -529,6 +529,11 @@ public class DatePickerDialog extends DialogFragment implements
     @Override
     public int getFirstDayOfWeek() {
         return mWeekStart;
+    }
+
+    @Override
+    public int[][] getDaysToHighlight() {
+        return daysToHighlight;
     }
 
     @Override

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/MonthView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/MonthView.java
@@ -184,6 +184,7 @@ public abstract class MonthView extends View {
     protected int mSelectedDayTextColor;
     protected int mMonthDayTextColor;
     protected int mTodayNumberColor;
+    protected int mNotHighlightedDayTextColor;
     protected int mDisabledDayTextColor;
     protected int mMonthTitleColor;
     protected int mMonthTitleBGColor;

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/MonthView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/MonthView.java
@@ -206,6 +206,7 @@ public abstract class MonthView extends View {
         mSelectedDayTextColor = res.getColor(R.color.mdtp_white);
         mMonthDayTextColor = res.getColor(R.color.mdtp_date_picker_month_day);
         mTodayNumberColor = res.getColor(R.color.mdtp_accent_color);
+        mNotHighlightedDayTextColor = res.getColor(R.color.mdtp_date_picker_text_not_highlighted);
         mDisabledDayTextColor = res.getColor(R.color.mdtp_date_picker_text_disabled);
         mMonthTitleColor = res.getColor(R.color.mdtp_white);
         mMonthTitleBGColor = res.getColor(R.color.mdtp_circle_background);

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/SimpleMonthView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/SimpleMonthView.java
@@ -35,16 +35,33 @@ public class SimpleMonthView extends MonthView {
                     mSelectedCirclePaint);
         }
 
-        // If we have a mindate or maxdate, gray out the day number if it's outside the range.
+                // If we have a mindate or maxdate, gray out the day number if it's outside the range.
         if (isOutOfRange(year, month, day)) {
             mMonthNumPaint.setColor(mDisabledDayTextColor);
-        } else if (mSelectedDay == day) {
-            mMonthNumPaint.setColor(mSelectedDayTextColor);
-        } else if (mHasToday && mToday == day) {
-            mMonthNumPaint.setColor(mTodayNumberColor);
-        } else {
-            mMonthNumPaint.setColor(mDayTextColor);
+        } else if (checkIfDayShouldBeHighlighted(year, month, day)) {
+            if (mSelectedDay == day) {
+                mMonthNumPaint.setColor(mSelectedDayTextColor);
+            } else if (mHasToday && mToday == day) {
+                mMonthNumPaint.setColor(mTodayNumberColor);
+            } else {
+                mMonthNumPaint.setColor(mDayTextColor);
+            }
         }
+        else {
+            mMonthNumPaint.setColor(mNotHighlightedDayTextColor);
+        }
+
         canvas.drawText(String.format("%d", day), x, y, mMonthNumPaint);
+    }
+
+    public boolean checkIfDayShouldBeHighlighted(int year, int month, int day) {
+        if (mController.getDaysToHighlight() == null)
+            return true;
+
+        for (int[] z : mController.getDaysToHighlight())
+            if ((z[2] == year) && (z[1] == month) && (z[0] == day))
+                return true;
+
+        return false;
     }
 }

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -32,6 +32,7 @@
     <color name="mdtp_neutral_pressed">#33999999</color>
     <color name="mdtp_accent_color_dark">#00796b</color>
     <color name="mdtp_date_picker_text_normal">#ff212121</color>
+    <color name="mdtp_date_picker_text_not_highlighted">#ccc</color>
     <color name="mdtp_date_picker_text_disabled">#ccc</color>
     <color name="mdtp_date_picker_month_day">#767676</color>
 


### PR DESCRIPTION
An array of days to be highlighted (in the form of a multi-dimensional array containing day/month/year for each date to be highlighted) can be passed to the DatePickerDialog - 

The highlighted / non-highlighted day text colors can be edited by defining colors in your main colors.xml file:
Highlighted text color res -  mdtp_date_picker_text_normal
Non-highlighted text color res - mdtp_date_picker_text_not_highlighted