### PR TITLE
Add a title to the TimePickerDialog (solves #16)

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -57,6 +57,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
     private static final String KEY_HOUR_OF_DAY = "hour_of_day";
     private static final String KEY_MINUTE = "minute";
     private static final String KEY_IS_24_HOUR_VIEW = "is_24_hour_view";
+    private static final String KEY_TITLE = "dialog_title";
     private static final String KEY_CURRENT_ITEM_SHOWING = "current_item_showing";
     private static final String KEY_IN_KB_MODE = "in_kb_mode";
     private static final String KEY_TYPED_TIMES = "typed_times";
@@ -98,6 +99,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
     private int mInitialHourOfDay;
     private int mInitialMinute;
     private boolean mIs24HourMode;
+    private String mTitle;
     private boolean mThemeDark;
 
     // For hardware IME input.
@@ -156,7 +158,19 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
         mInitialMinute = minute;
         mIs24HourMode = is24HourMode;
         mInKbMode = false;
+        mTitle = "";
         mThemeDark = false;
+    }
+
+    /**
+     * Set a title. NOTE: this will only take effect with the next onCreateView
+     */
+    public void setTitle(String title) {
+        mTitle = title;
+    }
+
+    public String getTitle() {
+        return mTitle;
     }
 
     /**
@@ -198,6 +212,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
             mInitialMinute = savedInstanceState.getInt(KEY_MINUTE);
             mIs24HourMode = savedInstanceState.getBoolean(KEY_IS_24_HOUR_VIEW);
             mInKbMode = savedInstanceState.getBoolean(KEY_IN_KB_MODE);
+            mTitle = savedInstanceState.getString(KEY_TITLE);
             mThemeDark = savedInstanceState.getBoolean(KEY_DARK_THEME);
         }
     }
@@ -339,6 +354,13 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
             mTypedTimes = new ArrayList<Integer>();
         }
 
+        // Set the title (if any)
+        TextView timePickerHeader = (TextView) view.findViewById(R.id.time_picker_header);
+        if (!mTitle.isEmpty()) {
+            timePickerHeader.setVisibility(TextView.VISIBLE);
+            timePickerHeader.setText(mTitle);
+        }
+
         // Set the theme at the end so that the initialize()s above don't counteract the theme.
         mTimePicker.setTheme(getActivity().getApplicationContext(), mThemeDark);
         // Prepare some colors to use.
@@ -424,6 +446,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
             if (mInKbMode) {
                 outState.putIntegerArrayList(KEY_TYPED_TIMES, mTypedTimes);
             }
+            outState.putString(KEY_TITLE, mTitle);
             outState.putBoolean(KEY_DARK_THEME, mThemeDark);
         }
     }

--- a/library/src/main/res/layout-land/mdtp_time_picker_dialog.xml
+++ b/library/src/main/res/layout-land/mdtp_time_picker_dialog.xml
@@ -33,6 +33,16 @@
         android:layout_height="@dimen/mdtp_time_picker_height"
         android:layout_width="wrap_content"
         android:orientation="vertical" >
+        <TextView
+            android:id="@+id/time_picker_header"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:textSize="@dimen/mdtp_time_picker_header_text_size"
+            android:padding="5dp"
+            android:textColor="@color/mdtp_white"
+            android:background="@color/mdtp_accent_color_dark"/>
         <FrameLayout
             android:id="@+id/time_display_background"
             android:layout_width="@dimen/mdtp_left_side_width"

--- a/library/src/main/res/layout-land/mdtp_time_picker_dialog.xml
+++ b/library/src/main/res/layout-land/mdtp_time_picker_dialog.xml
@@ -40,6 +40,7 @@
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
             android:textSize="@dimen/mdtp_time_picker_header_text_size"
+            android:singleLine="true"
             android:padding="5dp"
             android:textColor="@color/mdtp_white"
             android:background="@color/mdtp_accent_color_dark"/>

--- a/library/src/main/res/layout/mdtp_time_picker_dialog.xml
+++ b/library/src/main/res/layout/mdtp_time_picker_dialog.xml
@@ -21,17 +21,30 @@
     android:orientation="vertical"
     android:background="@color/mdtp_background_color"
     android:focusable="true" >
-    <FrameLayout
+    <LinearLayout
         android:id="@+id/time_display_background"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:orientation="vertical"
         android:background="@color/mdtp_accent_color" >
+
+        <TextView
+            android:id="@+id/time_picker_header"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:textSize="@dimen/mdtp_time_picker_header_text_size"
+            android:padding="5dp"
+            android:textColor="@color/mdtp_white"
+            android:background="@color/mdtp_accent_color_dark"/>
+
         <include
             layout="@layout/mdtp_time_header_label"
             android:layout_width="match_parent"
             android:layout_height="@dimen/mdtp_header_height"
             android:layout_gravity="center" />
-    </FrameLayout>
+    </LinearLayout>
     <com.wdullaer.materialdatetimepicker.time.RadialPickerLayout
         android:id="@+id/time_picker"
         android:layout_height="@dimen/mdtp_time_picker_height"

--- a/library/src/main/res/layout/mdtp_time_picker_dialog.xml
+++ b/library/src/main/res/layout/mdtp_time_picker_dialog.xml
@@ -35,6 +35,7 @@
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
             android:textSize="@dimen/mdtp_time_picker_header_text_size"
+            android:singleLine="true"
             android:padding="5dp"
             android:textColor="@color/mdtp_white"
             android:background="@color/mdtp_accent_color_dark"/>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -56,6 +56,7 @@
     <dimen name="mdtp_selected_date_day_size">70dp</dimen>
     <dimen name="mdtp_selected_date_month_size">25dp</dimen>
     <dimen name="mdtp_date_picker_header_text_size">12dp</dimen>
+    <dimen name="mdtp_time_picker_header_text_size">22sp</dimen>
     <dimen name="mdtp_month_label_size">14sp</dimen>
     <dimen name="mdtp_day_number_size">12sp</dimen>
     <dimen name="mdtp_year_label_height">64dp</dimen>


### PR DESCRIPTION
Just use .setTitle() on a TimePickerDialog instance and you're good to go. Of course, this is all optional and there is no title by default.

Let me know if I messed up something, feel free to rename stuff :).