### PR TITLE
Added support for seconds in time picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Set whether the dialogs should vibrate the device when a selection is made. This
 * `dismissOnPause(boolean dismissOnPause)`  
 Set whether the picker dismisses itself when the parent Activity is paused or whether it recreates itself when the Activity is resumed.
 
+* `setSecondsEnabled(boolean enabled)`  
+Set whether the time picker supports seconds. Disabled per default.
+
 
 ## FAQ
 

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialPickerLayout.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialPickerLayout.java
@@ -267,6 +267,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
     public void setTime(int hours, int minutes) {
         setItem(HOUR_INDEX, hours);
         setItem(MINUTE_INDEX, minutes);
+        setItem(SECOND_INDEX, 0);
     }
 
     public void setTime(int hours, int minutes, int seconds) {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialPickerLayout.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialPickerLayout.java
@@ -610,28 +610,37 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
         mCurrentItemShowing = index;
 
         if (animate && (index != lastIndex)) {
-            ObjectAnimator[] anims = new ObjectAnimator[6];
-            if (index == SECOND_INDEX) {
+            ObjectAnimator[] anims = new ObjectAnimator[4];
+            if (index == SECOND_INDEX && lastIndex == MINUTE_INDEX) {
+                anims[0] = mMinuteRadialTextsView.getDisappearAnimator();
+                anims[1] = mMinuteRadialSelectorView.getDisappearAnimator();
+                anims[2] = mSecondRadialTextsView.getReappearAnimator();
+                anims[3] = mSecondRadialSelectorView.getReappearAnimator();
+            } else if (index == SECOND_INDEX && lastIndex == HOUR_INDEX) {
                 anims[0] = mHourRadialTextsView.getDisappearAnimator();
                 anims[1] = mHourRadialSelectorView.getDisappearAnimator();
-                anims[2] = mMinuteRadialTextsView.getDisappearAnimator();
-                anims[3] = mMinuteRadialSelectorView.getDisappearAnimator();
-                anims[4] = mSecondRadialTextsView.getReappearAnimator();
-                anims[5] = mSecondRadialSelectorView.getReappearAnimator();
-            } else if (index == MINUTE_INDEX) {
+                anims[2] = mSecondRadialTextsView.getReappearAnimator();
+                anims[3] = mSecondRadialSelectorView.getReappearAnimator();
+            } else if (index == MINUTE_INDEX && lastIndex == HOUR_INDEX) {
+                anims[0] = mHourRadialTextsView.getDisappearAnimator();
+                anims[1] = mHourRadialSelectorView.getDisappearAnimator();
+                anims[2] = mMinuteRadialTextsView.getReappearAnimator();
+                anims[3] = mMinuteRadialSelectorView.getReappearAnimator();
+            } else if (index == MINUTE_INDEX && lastIndex == SECOND_INDEX) {
                 anims[0] = mSecondRadialTextsView.getDisappearAnimator();
                 anims[1] = mSecondRadialSelectorView.getDisappearAnimator();
-                anims[2] = mHourRadialTextsView.getDisappearAnimator();
-                anims[3] = mHourRadialSelectorView.getDisappearAnimator();
-                anims[4] = mMinuteRadialTextsView.getReappearAnimator();
-                anims[5] = mMinuteRadialSelectorView.getReappearAnimator();
-            } else if (index == HOUR_INDEX) {
-                anims[0] = mHourRadialTextsView.getReappearAnimator();
-                anims[1] = mHourRadialSelectorView.getReappearAnimator();
-                anims[2] = mMinuteRadialTextsView.getDisappearAnimator();
-                anims[3] = mMinuteRadialSelectorView.getDisappearAnimator();
-                anims[4] = mSecondRadialTextsView.getDisappearAnimator();
-                anims[5] = mSecondRadialSelectorView.getDisappearAnimator();
+                anims[2] = mMinuteRadialTextsView.getReappearAnimator();
+                anims[3] = mMinuteRadialSelectorView.getReappearAnimator();
+            } else if (index == HOUR_INDEX && lastIndex == SECOND_INDEX) {
+                anims[0] = mSecondRadialTextsView.getDisappearAnimator();
+                anims[1] = mSecondRadialSelectorView.getDisappearAnimator();
+                anims[2] = mHourRadialTextsView.getReappearAnimator();
+                anims[3] = mHourRadialSelectorView.getReappearAnimator();
+            } else if (index == HOUR_INDEX && lastIndex == MINUTE_INDEX) {
+                anims[0] = mMinuteRadialTextsView.getDisappearAnimator();
+                anims[1] = mMinuteRadialSelectorView.getDisappearAnimator();
+                anims[2] = mHourRadialTextsView.getReappearAnimator();
+                anims[3] = mHourRadialSelectorView.getReappearAnimator();
             }
 
             if (mTransition != null && mTransition.isRunning()) {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -222,7 +222,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
         return mThemeDark;
     }
 
-    public void enableSeconds(boolean enabled) {
+    public void setSecondsEnabled(boolean enabled) {
         mEnableSeconds = enabled;
     }
 

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -63,6 +63,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
     private static final String KEY_ACCENT = "accent";
     private static final String KEY_VIBRATE = "vibrate";
     private static final String KEY_DISMISS = "dismiss";
+    private static final String KEY_ENABLE_SECONDS = "enable_seconds";
 
     public static final int HOUR_INDEX = 0;
     public static final int MINUTE_INDEX = 1;
@@ -106,6 +107,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
     private boolean mVibrate;
     private int mAccentColor = -1;
     private boolean mDismissOnPause;
+    private boolean mEnableSeconds;
 
     // For hardware IME input.
     private char mPlaceholderText;
@@ -168,6 +170,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
         mAccentColor = -1;
         mVibrate = true;
         mDismissOnPause = false;
+        mEnableSeconds = false;
     }
 
     /**
@@ -194,6 +197,10 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
 
     public boolean isThemeDark() {
         return mThemeDark;
+    }
+
+    public void enableSeconds(boolean enabled) {
+        mEnableSeconds = enabled;
     }
 
     /**
@@ -244,6 +251,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
             mThemeDark = savedInstanceState.getBoolean(KEY_DARK_THEME);
             mAccentColor = savedInstanceState.getInt(KEY_ACCENT);
             mVibrate = savedInstanceState.getBoolean(KEY_VIBRATE);
+            mEnableSeconds = savedInstanceState.getBoolean(KEY_ENABLE_SECONDS);
         }
     }
 
@@ -479,6 +487,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
             outState.putBoolean(KEY_DARK_THEME, mThemeDark);
             outState.putInt(KEY_ACCENT, mAccentColor);
             outState.putBoolean(KEY_VIBRATE, mVibrate);
+            outState.putBoolean(KEY_ENABLE_SECONDS, mEnableSeconds);
         }
     }
 

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -19,6 +19,7 @@ package com.wdullaer.materialdatetimepicker.time;
 import android.animation.ObjectAnimator;
 import android.app.ActionBar.LayoutParams;
 import android.app.DialogFragment;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.os.Bundle;
@@ -288,6 +289,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
             Bundle savedInstanceState) {
         getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
 
+        Context context = getActivity().getApplicationContext();
         View view = inflater.inflate(R.layout.mdtp_time_picker_dialog, null);
         KeyboardListener keyboardListener = new KeyboardListener();
         view.findViewById(R.id.time_picker_dialog).setOnKeyListener(keyboardListener);
@@ -390,14 +392,10 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
         if (mIs24HourMode) {
             mAmPmTextView.setVisibility(View.GONE);
 
-            RelativeLayout.LayoutParams paramsSeparator = new RelativeLayout.LayoutParams(
-                    LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
-            paramsSeparator.addRule(RelativeLayout.CENTER_IN_PARENT);
-            TextView separatorView = (TextView) view.findViewById(R.id.separator);
-            separatorView.setLayoutParams(paramsSeparator);
         } else {
+
             mAmPmTextView.setVisibility(View.VISIBLE);
-            updateAmPmDisplay(mInitialHourOfDay < 12? AM : PM);
+            updateAmPmDisplay(mInitialHourOfDay < 12 ? AM : PM);
             mAmPmHitspace.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -405,13 +403,59 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
                     int amOrPm = mTimePicker.getIsCurrentlyAmOrPm();
                     if (amOrPm == AM) {
                         amOrPm = PM;
-                    } else if (amOrPm == PM){
+                    } else if (amOrPm == PM) {
                         amOrPm = AM;
                     }
                     updateAmPmDisplay(amOrPm);
                     mTimePicker.setAmOrPm(amOrPm);
                 }
             });
+        }
+
+        // Hide seconds if disabled
+        if (!mEnableSeconds) {
+            mSecondSpaceView.setVisibility(View.GONE);
+            view.findViewById(R.id.separator_seconds).setVisibility(View.GONE);
+        }
+
+        // Center stuff depending on what's visible
+        if (mIs24HourMode && !mEnableSeconds) {
+
+            // center first separator
+            RelativeLayout.LayoutParams paramsSeparator = new RelativeLayout.LayoutParams(
+                    LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+            paramsSeparator.addRule(RelativeLayout.CENTER_IN_PARENT);
+            TextView separatorView = (TextView) view.findViewById(R.id.separator);
+            separatorView.setLayoutParams(paramsSeparator);
+
+        } else {
+            if (mEnableSeconds) {
+
+                // link separator to minutes
+                final View separator = view.findViewById(R.id.separator);
+                RelativeLayout.LayoutParams paramsSeparator = new RelativeLayout.LayoutParams(
+                        LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+                paramsSeparator.addRule(RelativeLayout.LEFT_OF, R.id.minutes_space);
+                paramsSeparator.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
+                separator.setLayoutParams(paramsSeparator);
+
+                if (!mIs24HourMode) {
+
+                    // center minutes
+                    RelativeLayout.LayoutParams paramsMinutes = new RelativeLayout.LayoutParams(
+                            LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+                    paramsMinutes.addRule(RelativeLayout.CENTER_IN_PARENT);
+                    mMinuteSpaceView.setLayoutParams(paramsMinutes);
+
+                } else {
+
+                    // move minutes to right of center
+                    RelativeLayout.LayoutParams paramsMinutes = new RelativeLayout.LayoutParams(
+                                    LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+                    paramsMinutes.addRule(RelativeLayout.RIGHT_OF, R.id.center_view);
+                    mMinuteSpaceView.setLayoutParams(paramsMinutes);
+                }
+            }
         }
 
         mAllowAutoAdvance = true;
@@ -441,7 +485,7 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
         }
 
         // Set the theme at the end so that the initialize()s above don't counteract the theme.
-        mTimePicker.setTheme(getActivity().getApplicationContext(), mThemeDark);
+        mTimePicker.setTheme(context, mThemeDark);
 
         //If an accent color has not been set manually, try and get it from the context
         if (mAccentColor == -1) {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -593,10 +593,16 @@ public class TimePickerDialog extends DialogFragment implements OnValueSelectedL
             }
 
             Utils.tryAccessibilityAnnounce(mTimePicker, announcement);
-        } else if (pickerIndex == MINUTE_INDEX){
+        } else if (pickerIndex == MINUTE_INDEX) {
             setMinute(newValue);
-            mTimePicker.setContentDescription(mMinutePickerDescription + ": " + newValue);
-        } else if (pickerIndex == SECOND_INDEX){
+            if (mAllowAutoAdvance && autoAdvance) {
+                setCurrentItemShowing(SECOND_INDEX, true, true, false);
+                Utils.tryAccessibilityAnnounce(mTimePicker, String.format("%02d", newValue));
+            } else {
+                mTimePicker.setContentDescription(mMinutePickerDescription + ": " + newValue);
+            }
+
+        } else if (pickerIndex == SECOND_INDEX) {
             setSecond(newValue);
             mTimePicker.setContentDescription(mSecondPickerDescription + ": " + newValue);
         } else if (pickerIndex == AMPM_INDEX) {

--- a/library/src/main/res/layout/mdtp_time_header_label.xml
+++ b/library/src/main/res/layout/mdtp_time_header_label.xml
@@ -123,22 +123,21 @@
             android:layout_centerVertical="true"
             android:visibility="invisible"
             android:textColor="@color/mdtp_accent_color_focused"
-            style="@style/mdtp_time_label"
+            style="@style/mdtp_time_label_small"
             android:importantForAccessibility="no" />
         <FrameLayout
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_alignRight="@+id/seconds_space"
             android:layout_alignLeft="@+id/seconds_space"
-            android:layout_marginLeft="@dimen/mdtp_extra_time_label_margin"
-            android:layout_marginRight="@dimen/mdtp_extra_time_label_margin"
+            android:layout_marginLeft="-15dp"
+            android:layout_marginRight="-15dp"
             android:layout_centerVertical="true" >
             <com.wdullaer.materialdatetimepicker.AccessibleTextView
                 android:id="@+id/seconds"
-                style="@style/mdtp_time_label"
+                style="@style/mdtp_time_label_small"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="8dp"
                 android:gravity="center_horizontal"
                 android:text="@string/mdtp_time_placeholder"
                 android:layout_gravity="center"

--- a/library/src/main/res/layout/mdtp_time_header_label.xml
+++ b/library/src/main/res/layout/mdtp_time_header_label.xml
@@ -19,7 +19,8 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:layout_gravity="center"
-      android:background="@color/mdtp_accent_color" >
+      android:background="@color/mdtp_accent_color"
+      android:clipChildren="false">
         <View
             android:id="@+id/center_view"
             android:layout_width="1dp"
@@ -44,9 +45,8 @@
             android:layout_height="match_parent"
             android:layout_alignRight="@+id/hour_space"
             android:layout_alignLeft="@+id/hour_space"
-            android:layout_marginLeft="@dimen/mdtp_extra_time_label_margin"
-            android:layout_marginRight="@dimen/mdtp_extra_time_label_margin"
-            android:layout_centerVertical="true" >
+            android:layout_centerVertical="true"
+            android:clipChildren="false">
             <com.wdullaer.materialdatetimepicker.AccessibleTextView
                 android:id="@+id/hours"
                 android:layout_width="wrap_content"

--- a/library/src/main/res/layout/mdtp_time_header_label.xml
+++ b/library/src/main/res/layout/mdtp_time_header_label.xml
@@ -100,6 +100,51 @@
                 android:layout_gravity="center"
                 android:textColor="@color/mdtp_accent_color_focused" />
         </FrameLayout>
+
+        <TextView
+            android:id="@+id/separator_seconds"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/mdtp_time_separator"
+            android:paddingLeft="@dimen/mdtp_separator_padding"
+            android:paddingRight="@dimen/mdtp_separator_padding"
+            android:layout_toRightOf="@+id/minutes_space"
+            android:layout_centerVertical="true"
+            android:textColor="@color/mdtp_accent_color_focused"
+            style="@style/mdtp_time_label"
+            android:importantForAccessibility="no" />
+
+        <TextView
+            android:id="@+id/seconds_space"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/mdtp_time_placeholder"
+            android:layout_toRightOf="@+id/separator_seconds"
+            android:layout_centerVertical="true"
+            android:visibility="invisible"
+            android:textColor="@color/mdtp_accent_color_focused"
+            style="@style/mdtp_time_label"
+            android:importantForAccessibility="no" />
+        <FrameLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_alignRight="@+id/seconds_space"
+            android:layout_alignLeft="@+id/seconds_space"
+            android:layout_marginLeft="@dimen/mdtp_extra_time_label_margin"
+            android:layout_marginRight="@dimen/mdtp_extra_time_label_margin"
+            android:layout_centerVertical="true" >
+            <com.wdullaer.materialdatetimepicker.AccessibleTextView
+                android:id="@+id/seconds"
+                style="@style/mdtp_time_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:gravity="center_horizontal"
+                android:text="@string/mdtp_time_placeholder"
+                android:layout_gravity="center"
+                android:textColor="@color/mdtp_accent_color_focused" />
+        </FrameLayout>
+
         <com.wdullaer.materialdatetimepicker.AccessibleTextView
             android:id="@+id/ampm_hitspace"
             android:layout_width="@dimen/mdtp_ampm_label_size"
@@ -115,7 +160,7 @@
             android:text="@string/mdtp_time_placeholder"
             android:paddingLeft="@dimen/mdtp_ampm_left_padding"
             android:paddingRight="@dimen/mdtp_ampm_left_padding"
-            android:layout_toRightOf="@+id/minutes_space"
+            android:layout_toRightOf="@+id/seconds_space"
             android:layout_alignBaseline="@+id/separator"
             android:textColor="@color/mdtp_accent_color_focused"
             style="@style/mdtp_ampm_label"

--- a/library/src/main/res/values-sw600dp-land/dimens.xml
+++ b/library/src/main/res/values-sw600dp-land/dimens.xml
@@ -23,7 +23,7 @@
     <dimen name="mdtp_date_picker_header_height">45dp</dimen>
     <dimen name="mdtp_time_label_right_padding">16sp</dimen>
     <dimen name="mdtp_time_label_size">64sp</dimen>
-    <dimen name="mdtp_time_label_small_size">32sp</dimen>
+    <dimen name="mdtp_time_label_subscript_size">32sp</dimen>
     <dimen name="mdtp_ampm_label_size">16sp</dimen>
     <dimen name="mdtp_ampm_left_padding">6dip</dimen>
     <dimen name="mdtp_separator_padding">5dip</dimen>

--- a/library/src/main/res/values-sw600dp-land/dimens.xml
+++ b/library/src/main/res/values-sw600dp-land/dimens.xml
@@ -23,6 +23,7 @@
     <dimen name="mdtp_date_picker_header_height">45dp</dimen>
     <dimen name="mdtp_time_label_right_padding">16sp</dimen>
     <dimen name="mdtp_time_label_size">64sp</dimen>
+    <dimen name="mdtp_time_label_small_size">32sp</dimen>
     <dimen name="mdtp_ampm_label_size">16sp</dimen>
     <dimen name="mdtp_ampm_left_padding">6dip</dimen>
     <dimen name="mdtp_separator_padding">5dip</dimen>

--- a/library/src/main/res/values-sw600dp/dimens.xml
+++ b/library/src/main/res/values-sw600dp/dimens.xml
@@ -41,6 +41,7 @@
     <dimen name="mdtp_month_day_label_text_size">12sp</dimen>
 
     <dimen name="mdtp_time_label_size">76sp</dimen>
+    <dimen name="mdtp_time_label_small_size">38sp</dimen>
     <dimen name="mdtp_extra_time_label_margin">-50dp</dimen>
     <dimen name="mdtp_ampm_label_size">16sp</dimen>
     <dimen name="mdtp_ampm_left_padding">6dip</dimen>

--- a/library/src/main/res/values-sw600dp/dimens.xml
+++ b/library/src/main/res/values-sw600dp/dimens.xml
@@ -41,7 +41,7 @@
     <dimen name="mdtp_month_day_label_text_size">12sp</dimen>
 
     <dimen name="mdtp_time_label_size">76sp</dimen>
-    <dimen name="mdtp_time_label_small_size">38sp</dimen>
+    <dimen name="mdtp_time_label_subscript_size">38sp</dimen>
     <dimen name="mdtp_extra_time_label_margin">-50dp</dimen>
     <dimen name="mdtp_ampm_label_size">16sp</dimen>
     <dimen name="mdtp_ampm_left_padding">6dip</dimen>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -29,7 +29,7 @@
     <item name="mdtp_text_size_multiplier_outer" format="float" type="string">0.08</item>
 
     <dimen name="mdtp_time_label_size">60sp</dimen>
-    <dimen name="mdtp_time_label_small_size">30sp</dimen>
+    <dimen name="mdtp_time_label_subscript_size">30sp</dimen>
     <dimen name="mdtp_time_label_shift">-12dp</dimen>
     <dimen name="mdtp_extra_time_label_margin">-30dp</dimen>
     <dimen name="mdtp_ampm_label_size">16sp</dimen>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -29,6 +29,8 @@
     <item name="mdtp_text_size_multiplier_outer" format="float" type="string">0.08</item>
 
     <dimen name="mdtp_time_label_size">60sp</dimen>
+    <dimen name="mdtp_time_label_small_size">30sp</dimen>
+    <dimen name="mdtp_time_label_shift">-12dp</dimen>
     <dimen name="mdtp_extra_time_label_margin">-30dp</dimen>
     <dimen name="mdtp_ampm_label_size">16sp</dimen>
     <dimen name="mdtp_done_label_size">14sp</dimen>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -32,10 +32,18 @@
          [CHAR LIMIT=50]
     -->
     <string name="mdtp_minute_picker_description">Minutes circular slider</string>
+    <!--
+         Content description for the second selector in the time picker, which displays
+         selectable five-second intervals along the inside edge of a circle, as in an analog clock.
+         [CHAR LIMIT=50]
+    -->
+    <string name="mdtp_second_picker_description">Seconds circular slider</string>
     <!-- Accessibility announcement for hour circular picker [CHAR LIMIT=NONE] -->
     <string name="mdtp_select_hours">Select hours</string>
     <!-- Accessibility announcement for minute circular picker [CHAR LIMIT=NONE] -->
     <string name="mdtp_select_minutes">Select minutes</string>
+    <!-- Accessibility announcement for minute circular picker [CHAR LIMIT=NONE] -->
+    <string name="mdtp_select_seconds">Select seconds</string>
 
     <!--
         Content description for the month and day selector in the date picker, which displays

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -21,6 +21,11 @@
         <item name="android:textColor">@color/mdtp_numbers_text_color</item>
     </style>
 
+    <style name="mdtp_time_label_small" parent="mdtp_time_label">
+        <item name="android:textSize">@dimen/mdtp_time_label_small_size</item>
+        <item name="android:layout_marginBottom">@dimen/mdtp_time_label_shift</item>
+    </style>
+
     <style name="mdtp_ampm_label">
         <item name="android:textSize">@dimen/mdtp_ampm_label_size</item>
         <item name="android:textAllCaps">true</item>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -22,7 +22,7 @@
     </style>
 
     <style name="mdtp_time_label_small" parent="mdtp_time_label">
-        <item name="android:textSize">@dimen/mdtp_time_label_small_size</item>
+        <item name="android:textSize">@dimen/mdtp_time_label_subscript_size</item>
         <item name="android:layout_marginBottom">@dimen/mdtp_time_label_shift</item>
     </style>
 

--- a/sample/src/main/java/com/wdullaer/datetimepickerexample/MainActivity.java
+++ b/sample/src/main/java/com/wdullaer/datetimepickerexample/MainActivity.java
@@ -61,12 +61,23 @@ public class MainActivity extends AppCompatActivity implements
             @Override
             public void onClick(View v) {
                 Calendar now = Calendar.getInstance();
-                TimePickerDialog tpd = TimePickerDialog.newInstance(
-                        MainActivity.this,
-                        now.get(Calendar.HOUR_OF_DAY),
-                        now.get(Calendar.MINUTE),
-                        mode24Hours.isChecked()
-                );
+                TimePickerDialog tpd;
+                if (enableSeconds.isChecked()) {
+                    tpd = TimePickerDialog.newInstance(
+                            MainActivity.this,
+                            now.get(Calendar.HOUR_OF_DAY),
+                            now.get(Calendar.MINUTE),
+                            now.get(Calendar.SECOND),
+                            mode24Hours.isChecked()
+                    );
+                } else {
+                    tpd = TimePickerDialog.newInstance(
+                            MainActivity.this,
+                            now.get(Calendar.HOUR_OF_DAY),
+                            now.get(Calendar.MINUTE),
+                            mode24Hours.isChecked()
+                    );
+                }
                 tpd.setThemeDark(modeDarkTime.isChecked());
                 tpd.vibrate(vibrateTime.isChecked());
                 tpd.dismissOnPause(dismissTime.isChecked());

--- a/sample/src/main/java/com/wdullaer/datetimepickerexample/MainActivity.java
+++ b/sample/src/main/java/com/wdullaer/datetimepickerexample/MainActivity.java
@@ -122,11 +122,8 @@ public class MainActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onTimeSet(RadialPickerLayout view, int hourOfDay, int minute) {
-        String hourString = hourOfDay < 10 ? "0"+hourOfDay : ""+hourOfDay;
-        String minuteString = minute < 10 ? "0"+minute : ""+minute;
-        String time = "You picked the following time: "+hourString+"h"+minuteString;
-        timeTextView.setText(time);
+    public void onTimeSet(RadialPickerLayout view, int hourOfDay, int minute, int second) {
+        timeTextView.setText(String.format("You picked the following time: %02dh%02d:%02d", hourOfDay, minute, second));
     }
 
     @Override

--- a/sample/src/main/java/com/wdullaer/datetimepickerexample/MainActivity.java
+++ b/sample/src/main/java/com/wdullaer/datetimepickerexample/MainActivity.java
@@ -32,6 +32,7 @@ public class MainActivity extends AppCompatActivity implements
     private CheckBox dismissTime;
     private CheckBox dismissDate;
     private CheckBox titleTime;
+    private CheckBox enableSeconds;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -53,6 +54,7 @@ public class MainActivity extends AppCompatActivity implements
         dismissTime = (CheckBox) findViewById(R.id.dismiss_time);
         dismissDate = (CheckBox) findViewById(R.id.dismiss_date);
         titleTime = (CheckBox) findViewById(R.id.title_time);
+        enableSeconds = (CheckBox) findViewById(R.id.enable_seconds);
 
         // Show a timepicker when the timeButton is clicked
         timeButton.setOnClickListener(new View.OnClickListener() {
@@ -81,6 +83,9 @@ public class MainActivity extends AppCompatActivity implements
                     }
                 });
                 tpd.show(getFragmentManager(), "Timepickerdialog");
+                if (enableSeconds.isChecked()) {
+                    tpd.enableSeconds(true);
+                }
             }
         });
 

--- a/sample/src/main/java/com/wdullaer/datetimepickerexample/MainActivity.java
+++ b/sample/src/main/java/com/wdullaer/datetimepickerexample/MainActivity.java
@@ -95,7 +95,7 @@ public class MainActivity extends AppCompatActivity implements
                 });
                 tpd.show(getFragmentManager(), "Timepickerdialog");
                 if (enableSeconds.isChecked()) {
-                    tpd.enableSeconds(true);
+                    tpd.setSecondsEnabled(true);
                 }
             }
         });

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -58,6 +58,13 @@
             android:checked="false"/>
 
         <CheckBox
+            android:id="@+id/enable_seconds"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/enable_seconds"
+            android:checked="false"/>
+
+        <CheckBox
             android:id="@+id/title_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="vibrate_date">Vibrate on touch</string>
     <string name="dismiss_time">Dismiss on pause (eg: orientation change)</string>
     <string name="dismiss_date">Dismiss on pause (eg: orientation change)</string>
+    <string name="enable_seconds">Enable seconds</string>
     <string name="title_time">Show a title</string>
     <string name="action_settings">Settings</string>
 


### PR DESCRIPTION
This adds a new feature where the time picker contains support for querying seconds from the user. The control is the same as the minutes picker. The feature is disabled by default and can be enabled through `TimePickerDialog#setSecondsEnabled(boolean enable)`.

![time-picker-with-seconds](https://cloud.githubusercontent.com/assets/70426/10138467/e5f87358-65fe-11e5-9d15-3ea2bacb27e0.png)

I needed to change the callback method to receive seconds as well. This breaks BC but is easily fixed. However, if this is a problem, `OnTimeSetListener` could be converted to an abstract class with a default implementation of two methods, one receiving seconds and one not. However this would mean that different methods would be called depending on if seconds are enabled or not, causing potential confusion.

If accepted, this would solve #87.