### PR TITLE
Ability to set theme mode by style.xml

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:23.1.0'
+    compile 'com.android.support:support-v4:23.1.1'
 }
 
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/Utils.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/Utils.java
@@ -22,8 +22,10 @@ import android.animation.PropertyValuesHolder;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.os.Build;
+import android.support.annotation.AttrRes;
 import android.support.v4.content.ContextCompat;
 import android.util.TypedValue;
 import android.view.View;
@@ -154,5 +156,31 @@ public class Utils {
         }
         // Return the value in mdtp_accent_color
         return ContextCompat.getColor(context, R.color.mdtp_accent_color);
+    }
+
+    /**
+     * Gets dialog type (Light/Dark) from current theme
+     * @param context The context to use as reference for the boolean
+     * @param current Default value to return if cannot resolve the attribute
+     * @return true if dark mode, false if light.
+     */
+    public static boolean isDarkTheme(Context context, boolean current) {
+        return resolveBoolean(context, R.attr.mdtp_dark_theme, current);
+    }
+
+    /**
+     * Gets the required boolean value from the current context, if possible/available
+     * @param context The context to use as reference for the boolean
+     * @param attr Attribute id to resolve
+     * @param fallback Default value to return if no value is specified in theme
+     * @return the boolean value from current theme
+     */
+    private static boolean resolveBoolean(Context context, @AttrRes int attr, boolean fallback) {
+        TypedArray a = context.getTheme().obtainStyledAttributes(new int[]{attr});
+        try {
+            return a.getBoolean(0, fallback);
+        } finally {
+            a.recycle();
+        }
     }
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -118,6 +118,7 @@ public class DatePickerDialog extends DialogFragment implements
     private Calendar[] highlightedDays;
     private Calendar[] selectableDays;
     private boolean mThemeDark = false;
+    private boolean mThemeDarkChanged = false;
     private int mAccentColor = -1;
     private boolean mVibrate = true;
     private boolean mDismissOnPause = false;
@@ -194,6 +195,7 @@ public class DatePickerDialog extends DialogFragment implements
             mCalendar.set(Calendar.MONTH, savedInstanceState.getInt(KEY_SELECTED_MONTH));
             mCalendar.set(Calendar.DAY_OF_MONTH, savedInstanceState.getInt(KEY_SELECTED_DAY));
             mDefaultView = savedInstanceState.getInt(KEY_DEFAULT_VIEW);
+            mThemeDarkChanged = true;
         }
     }
 
@@ -266,6 +268,11 @@ public class DatePickerDialog extends DialogFragment implements
         final Activity activity = getActivity();
         mDayPickerView = new SimpleDayPickerView(activity, this);
         mYearPickerView = new YearPickerView(activity, this);
+
+        // if theme mode has not been set by java code, check if it is specified in Style.xml
+        if (!mThemeDarkChanged) {
+            mThemeDark = Utils.isDarkTheme(activity, mThemeDark);
+        }
 
         Resources res = getResources();
         mDayPickerDescription = res.getString(R.string.mdtp_day_picker_description);
@@ -469,6 +476,7 @@ public class DatePickerDialog extends DialogFragment implements
      */
     public void setThemeDark(boolean themeDark) {
         mThemeDark = themeDark;
+        mThemeDarkChanged = true;
     }
 
     /**

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/TextViewWithCircularIndicator.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/TextViewWithCircularIndicator.java
@@ -61,18 +61,19 @@ public class TextViewWithCircularIndicator extends TextView {
         mCirclePaint.setAlpha(SELECTED_CIRCLE_ALPHA);
     }
 
-    public void setAccentColor(int color) {
+    public void setAccentColor(int color, boolean darkMode) {
         mCircleColor = color;
         mCirclePaint.setColor(mCircleColor);
-        setTextColor(createTextColor(color));
+        setTextColor(createTextColor(color, darkMode));
     }
 
     /**
      * Programmatically set the color state list (see mdtp_date_picker_year_selector)
      * @param accentColor pressed state text color
+     * @param darkMode current theme mode
      * @return ColorStateList with pressed state
      */
-    private ColorStateList createTextColor(int accentColor) {
+    private ColorStateList createTextColor(int accentColor, boolean darkMode) {
         int[][] states = new int[][]{
                 new int[]{android.R.attr.state_pressed}, // pressed
                 new int[]{android.R.attr.state_selected}, // selected
@@ -81,8 +82,7 @@ public class TextViewWithCircularIndicator extends TextView {
         int[] colors = new int[]{
                 accentColor,
                 Color.WHITE,
-                Color.BLACK
-
+                darkMode ? Color.WHITE : Color.BLACK
         };
         return new ColorStateList(states, colors);
     }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/YearPickerView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/YearPickerView.java
@@ -110,7 +110,7 @@ public class YearPickerView extends ListView implements OnItemClickListener, OnD
         public View getView(int position, View convertView, ViewGroup parent) {
             TextViewWithCircularIndicator v = (TextViewWithCircularIndicator)
                     super.getView(position, convertView, parent);
-            v.setAccentColor(mController.getAccentColor());
+            v.setAccentColor(mController.getAccentColor(), mController.isThemeDark());
             v.requestLayout();
             int year = getYearFromTextView(v);
             boolean selected = mController.getSelectedDay().year == year;

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -109,6 +109,7 @@ public class TimePickerDialog extends DialogFragment implements
     private boolean mIs24HourMode;
     private String mTitle;
     private boolean mThemeDark;
+    private boolean mThemeDarkChanged;
     private boolean mVibrate;
     private int mAccentColor = -1;
     private boolean mDismissOnPause;
@@ -175,6 +176,7 @@ public class TimePickerDialog extends DialogFragment implements
         mInKbMode = false;
         mTitle = "";
         mThemeDark = false;
+        mThemeDarkChanged = false;
         mAccentColor = -1;
         mVibrate = true;
         mDismissOnPause = false;
@@ -197,6 +199,7 @@ public class TimePickerDialog extends DialogFragment implements
      */
     public void setThemeDark(boolean dark) {
         mThemeDark = dark;
+        mThemeDarkChanged = true;
     }
 
     public void setAccentColor(int color) {
@@ -306,6 +309,7 @@ public class TimePickerDialog extends DialogFragment implements
             mMinTime = savedInstanceState.getParcelable(KEY_MIN_TIME);
             mMaxTime = savedInstanceState.getParcelable(KEY_MAX_TIME);
             mEnableSeconds = savedInstanceState.getBoolean(KEY_ENABLE_SECONDS);
+            mThemeDarkChanged = true;
         }
     }
 
@@ -320,6 +324,11 @@ public class TimePickerDialog extends DialogFragment implements
         // If an accent color has not been set manually, get it from the context
         if (mAccentColor == -1) {
             mAccentColor = Utils.getAccentColorFromThemeIfAvailable(getActivity());
+        }
+
+        // if theme mode has not been set by java code, check if it is specified in Style.xml
+        if (!mThemeDarkChanged) {
+            mThemeDark = Utils.isDarkTheme(getActivity(), mThemeDark);
         }
 
         Resources res = getResources();

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     compile project(':library')
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    compile 'com.android.support:appcompat-v7:23.1.1'
 }

--- a/sample/src/main/java/com/wdullaer/datetimepickerexample/MainActivity.java
+++ b/sample/src/main/java/com/wdullaer/datetimepickerexample/MainActivity.java
@@ -10,6 +10,7 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
+import com.wdullaer.materialdatetimepicker.Utils;
 import com.wdullaer.materialdatetimepicker.date.DatePickerDialog;
 import com.wdullaer.materialdatetimepicker.time.RadialPickerLayout;
 import com.wdullaer.materialdatetimepicker.time.TimePickerDialog;
@@ -59,6 +60,10 @@ public class MainActivity extends AppCompatActivity implements
         titleDate = (CheckBox) findViewById(R.id.title_date);
         showYearFirst = (CheckBox) findViewById(R.id.show_year_first);
         enableSeconds = (CheckBox) findViewById(R.id.enable_seconds);
+
+        // check if picker mode is specified in Style.xml
+        modeDarkTime.setChecked(Utils.isDarkTheme(this, modeDarkTime.isChecked()));
+        modeDarkDate.setChecked(Utils.isDarkTheme(this, modeDarkDate.isChecked()));
 
         // Show a timepicker when the timeButton is clicked
         timeButton.setOnClickListener(new View.OnClickListener() {

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -6,6 +6,8 @@
         <item name="colorPrimary">#3f51b5</item>
         <item name="colorPrimaryDark">#303f9f</item>
         <item name="colorAccent">#ff4081</item>
+        <!-- Customize picker mode here. -->
+        <item name="mdtp_dark_theme">true</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Added ability to set theme mode by style.xml (no need to set it programmatically every time a picker is required) and fixed a small bug in year picker (black text on dark background when dark mode is enabled)