### PR TITLE
Adjust dimensions to better support small devices in landscape

### DIFF
--- a/library/src/main/res/values-h330dp/dimens.xml
+++ b/library/src/main/res/values-h330dp/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="mdtp_date_picker_view_animator_height">252dp</dimen>
+    <dimen name="mdtp_time_picker_height">300dip</dimen>
 </resources>

--- a/library/src/main/res/values-land/dimens.xml
+++ b/library/src/main/res/values-land/dimens.xml
@@ -21,11 +21,15 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"
     xmlns:android="http://schemas.android.com/apk/res/android" >
     <dimen name="mdtp_dialog_height">200dip</dimen>
-    <dimen name="mdtp_left_side_width">270dip</dimen>
+    <dimen name="mdtp_left_side_width">220dip</dimen>
 
     <dimen name="mdtp_selected_date_year_size">30dp</dimen>
     <dimen name="mdtp_selected_date_day_size">100dp</dimen>
     <dimen name="mdtp_selected_date_month_size">30dp</dimen>
 
-    <dimen name="mdtp_date_picker_view_animator_height">240dp</dimen>
+    <dimen name="mdtp_date_picker_component_width">220dp</dimen>
+    <dimen name="mdtp_date_picker_view_animator_height">220dp</dimen>
+
+    <dimen name="mdtp_picker_dimen">220dip</dimen>
+    <dimen name="mdtp_time_picker_height">270dip</dimen>
 </resources>

--- a/library/src/main/res/values-w560dp-land/dimens.xml
+++ b/library/src/main/res/values-w560dp-land/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="mdtp_date_picker_component_width">270dp</dimen>
+    <dimen name="mdtp_picker_dimen">270dip</dimen>
+    <dimen name="mdtp_left_side_width">270dip</dimen>
+</resources>


### PR DESCRIPTION
Make both the date and time picker look better in landscape on smaller devices (Nexus S, for example). While not a perfect solution, this addresses some of the concerns in #112, making the pickers at least usable on these devices, while keeping other screen sizes looking the same.

Date before:

![date-land-0](https://cloud.githubusercontent.com/assets/2530991/11879953/05c7e84a-a4c4-11e5-998c-0120ac95f5f8.png)

Date after:

![date-land-1](https://cloud.githubusercontent.com/assets/2530991/11879961/0f7ea720-a4c4-11e5-989f-c9698b0bd08e.png)

Time before:

![time-land-0](https://cloud.githubusercontent.com/assets/2530991/11879974/1b9c1a42-a4c4-11e5-8db3-1da974dd6881.png)

Time after:

![time-land-1](https://cloud.githubusercontent.com/assets/2530991/11879978/1f1757c2-a4c4-11e5-8063-86fa1f6c37ab.png)
