### PR TITLE
Adjust text sizes and dimensions for Large/Huge text on smaller devices

### DIFF
--- a/library/src/main/res/values-land/dimens.xml
+++ b/library/src/main/res/values-land/dimens.xml
@@ -20,8 +20,10 @@
 <resources
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"
     xmlns:android="http://schemas.android.com/apk/res/android" >
+    <dimen name="mdtp_time_label_size">44sp</dimen>
+
     <dimen name="mdtp_dialog_height">200dip</dimen>
-    <dimen name="mdtp_left_side_width">220dip</dimen>
+    <dimen name="mdtp_left_side_width">240dip</dimen>
 
     <dimen name="mdtp_selected_date_year_size">30dp</dimen>
     <dimen name="mdtp_selected_date_day_size">100dp</dimen>

--- a/library/src/main/res/values-land/dimens.xml
+++ b/library/src/main/res/values-land/dimens.xml
@@ -20,8 +20,6 @@
 <resources
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"
     xmlns:android="http://schemas.android.com/apk/res/android" >
-    <dimen name="mdtp_time_label_size">44sp</dimen>
-
     <dimen name="mdtp_dialog_height">200dip</dimen>
     <dimen name="mdtp_left_side_width">240dip</dimen>
 

--- a/library/src/main/res/values-w560dp-land/dimens.xml
+++ b/library/src/main/res/values-w560dp-land/dimens.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <dimen name="mdtp_time_label_size">60sp</dimen>
     <dimen name="mdtp_date_picker_component_width">270dp</dimen>
     <dimen name="mdtp_picker_dimen">270dip</dimen>
     <dimen name="mdtp_left_side_width">270dip</dimen>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -28,7 +28,7 @@
     <item name="mdtp_text_size_multiplier_inner" format="float" type="string">0.11</item>
     <item name="mdtp_text_size_multiplier_outer" format="float" type="string">0.08</item>
 
-    <dimen name="mdtp_time_label_size">54sp</dimen>
+    <dimen name="mdtp_time_label_size">60dp</dimen>
     <dimen name="mdtp_time_label_subscript_size">30sp</dimen>
     <dimen name="mdtp_time_label_shift">-12dp</dimen>
     <dimen name="mdtp_extra_time_label_margin">-30dp</dimen>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -28,7 +28,7 @@
     <item name="mdtp_text_size_multiplier_inner" format="float" type="string">0.11</item>
     <item name="mdtp_text_size_multiplier_outer" format="float" type="string">0.08</item>
 
-    <dimen name="mdtp_time_label_size">60sp</dimen>
+    <dimen name="mdtp_time_label_size">54sp</dimen>
     <dimen name="mdtp_time_label_subscript_size">30sp</dimen>
     <dimen name="mdtp_time_label_shift">-12dp</dimen>
     <dimen name="mdtp_extra_time_label_margin">-30dp</dimen>


### PR DESCRIPTION
Slight adjustments to text size and dimensions to allow the time header label to be fully visible on smaller devices when the text size is set to Large or Huge. Otherwise, the hour portion of the label disappears completely.

![screenshot-2015-12-21_13 17 05 691](https://cloud.githubusercontent.com/assets/2530991/11939224/4000c67e-a7e6-11e5-977a-c2bc45eadcd1.png)

An alternative strategy, if this doesn't seem ideal, would be changing the unit of the text sizes in the time header label from `sp` to `dp` so that the text size remains constant even if the user chooses Large or Huge text. That would remove the need to adjust the numeric sizes at all.