### PR TITLE
Adjust time picker slightly to account for two digit hours

### DIFF
--- a/library/src/main/res/values-land/dimens.xml
+++ b/library/src/main/res/values-land/dimens.xml
@@ -21,7 +21,7 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"
     xmlns:android="http://schemas.android.com/apk/res/android" >
     <dimen name="mdtp_dialog_height">200dip</dimen>
-    <dimen name="mdtp_left_side_width">220dip</dimen>
+    <dimen name="mdtp_left_side_width">240dip</dimen>
 
     <dimen name="mdtp_selected_date_year_size">30dp</dimen>
     <dimen name="mdtp_selected_date_day_size">100dp</dimen>


### PR DESCRIPTION
This fixes landscape mode on small devices, even with normal text size.

![screenshot-2016-01-11_14 30 59 442](https://cloud.githubusercontent.com/assets/2530991/12245729/f6f73f5e-b86f-11e5-9d4d-2a263a00db89.png)
