### PR TITLE
Optionally hide title in DatePickerDialog

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -136,6 +136,7 @@ public class DatePickerDialog extends DialogFragment implements
     private String mOkString;
     private int mCancelResid = R.string.mdtp_cancel;
     private String mCancelString;
+    private boolean mDayOfWeekVisible;
 
     private HapticFeedbackController mHapticFeedbackController;
 
@@ -351,7 +352,14 @@ public class DatePickerDialog extends DialogFragment implements
         if (mAccentColor == -1) {
             mAccentColor = Utils.getAccentColorFromThemeIfAvailable(getActivity());
         }
-        if(mDayOfWeekView != null) mDayOfWeekView.setBackgroundColor(Utils.darkenColor(mAccentColor));
+        if(mDayOfWeekView != null) {
+            mDayOfWeekView.setBackgroundColor(Utils.darkenColor(mAccentColor));
+            if (mDayOfWeekVisible) {
+                mDayOfWeekView.setVisibility(View.VISIBLE);
+            } else {
+                mDayOfWeekView.setVisibility(View.GONE);
+            }
+        }
         view.findViewById(R.id.day_picker_selected_date_layout).setBackgroundColor(mAccentColor);
         okButton.setTextColor(mAccentColor);
         cancelButton.setTextColor(mAccentColor);
@@ -947,10 +955,6 @@ public class DatePickerDialog extends DialogFragment implements
     }
 
     public void setDayOfWeekVisibility(boolean visibility) {
-        if (visibility) {
-            mDayOfWeekView.setVisibility(View.VISIBLE);
-        } else {
-            mDayOfWeekView.setVisibility(View.GONE);
-        }
+        mDayOfWeekVisible = visibility;
     }
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -136,7 +136,7 @@ public class DatePickerDialog extends DialogFragment implements
     private String mOkString;
     private int mCancelResid = R.string.mdtp_cancel;
     private String mCancelString;
-    private boolean mDayOfWeekVisible = true;
+    private boolean mTitleVisible = true;
 
     private HapticFeedbackController mHapticFeedbackController;
 
@@ -354,7 +354,7 @@ public class DatePickerDialog extends DialogFragment implements
         }
         if(mDayOfWeekView != null) {
             mDayOfWeekView.setBackgroundColor(Utils.darkenColor(mAccentColor));
-            if (mDayOfWeekVisible) {
+            if (mTitleVisible) {
                 mDayOfWeekView.setVisibility(View.VISIBLE);
             } else {
                 mDayOfWeekView.setVisibility(View.GONE);
@@ -954,7 +954,7 @@ public class DatePickerDialog extends DialogFragment implements
         }
     }
 
-    public void setDayOfWeekVisibility(boolean visibility) {
-        mDayOfWeekVisible = visibility;
+    public void setTitleVisibility(boolean visibility) {
+        mTitleVisible = visibility;
     }
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -945,4 +945,12 @@ public class DatePickerDialog extends DialogFragment implements
                     mCalendar.get(Calendar.MONTH), mCalendar.get(Calendar.DAY_OF_MONTH));
         }
     }
+
+    public void setDayOfWeekVisibility(boolean visibility) {
+        if (visibility) {
+            mDayOfWeekView.setVisibility(View.VISIBLE);
+        } else {
+            mDayOfWeekView.setVisibility(View.GONE);
+        }
+    }
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -136,7 +136,7 @@ public class DatePickerDialog extends DialogFragment implements
     private String mOkString;
     private int mCancelResid = R.string.mdtp_cancel;
     private String mCancelString;
-    private boolean mDayOfWeekVisible;
+    private boolean mDayOfWeekVisible = true;
 
     private HapticFeedbackController mHapticFeedbackController;
 


### PR DESCRIPTION
DatePickerDialog.setTitleVisibility(boolean visibility) method added for hiding title. By default it is set ti visible as it is now.