### PR TITLE
fixed wrong behaviour of nearest date search 

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/Utils.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/Utils.java
@@ -30,6 +30,9 @@ import android.support.v4.content.ContextCompat;
 import android.util.TypedValue;
 import android.view.View;
 
+import java.util.Calendar;
+import java.util.Date;
+
 /**
  * Utility helper functions for time and date pickers.
  */
@@ -182,5 +185,21 @@ public class Utils {
         } finally {
             a.recycle();
         }
+    }
+
+    /**
+     * Trim date to midnight, leave date unchanged and set time to 00:00:00.000
+     * @param date Date to rounding
+     * @return rounded date
+     */
+    public static Calendar trimToMidnight(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        calendar.set(Calendar.MILLISECOND, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+
+        return calendar;
     }
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -935,7 +935,7 @@ public class DatePickerDialog extends DialogFragment implements
             long distance = Long.MAX_VALUE;
             Calendar currentBest = calendar;
             for (Calendar c : selectableDays) {
-                long newDistance = Math.abs(calendar.getTimeInMillis() - c.getTimeInMillis());
+                long newDistance = Math.abs(Utils.trimToMidnight(calendar.getTime()).getTimeInMillis() - Utils.trimToMidnight(c.getTime()).getTimeInMillis());
                 if(newDistance < distance) {
                     distance = newDistance;
                     currentBest = c;


### PR DESCRIPTION
This is hotfix for not correctly working of search of the nearest date in list of selectable days.
What is wrong: mCalendar is initialised with current time and date, date is later changed to requested date obtained from newInstance(). Time of mCalendar (hour, min, sec, milllis) leaves unaffected. And this mCalendar variable is compared with values from selectableDays array. When selectableDays are rounded to midnight (and this is our case), mCalendar with actual date is after midday wrongly set to +1 day (because of smaller diff between time of mCalendar and start of tomorrow). All compared dates have to be rounded to midnight.
This is probably same issue as https://github.com/wdullaer/MaterialDateTimePicker/issues/200
Thank you!