### PR TITLE
Implementation for custom day abbreviations

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerController.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerController.java
@@ -52,4 +52,6 @@ public interface DatePickerController {
     boolean isOutOfRange(int year, int month, int day);
 
     void tryVibrate();
+
+    String dayAbbreviationForDay(int day);
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -50,6 +50,7 @@ import com.wdullaer.materialdatetimepicker.Utils;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 
@@ -148,6 +149,9 @@ public class DatePickerDialog extends DialogFragment implements
     private String mSelectDay;
     private String mYearPickerDescription;
     private String mSelectYear;
+
+    //Day abbreviations
+    private HashMap <Integer,String> dayAbbreviations =  new HashMap<Integer,String>();
 
     /**
      * The callback used to indicate the user is done filling in the date.
@@ -781,6 +785,14 @@ public class DatePickerDialog extends DialogFragment implements
         setToNearestDate(calendar);
     }
 
+    /**
+     * Set the custom abbreviations for the days
+     * @param abbreviations HashMap<Integer,String>
+     */
+    public void setDayAbbreviations(HashMap<Integer,String> abbreviations) {
+        this.dayAbbreviations=abbreviations;
+    }
+
     @Override
     public void onClick(View v) {
         tryVibrate();
@@ -1060,5 +1072,14 @@ public class DatePickerDialog extends DialogFragment implements
             mCallBack.onDateSet(DatePickerDialog.this, mCalendar.get(Calendar.YEAR),
                     mCalendar.get(Calendar.MONTH), mCalendar.get(Calendar.DAY_OF_MONTH));
         }
+    }
+
+    @Override
+    public String dayAbbreviationForDay(int day) {
+        Integer key=new Integer(day);
+        if (dayAbbreviations.containsKey(key)){
+            return dayAbbreviations.get(key);
+        }
+        return null;
     }
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/MonthView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/MonthView.java
@@ -621,44 +621,47 @@ public abstract class MonthView extends View {
      * @return The weekday label
      */
     private String getWeekDayLabel(Calendar day) {
-        Locale locale = Locale.getDefault();
+        String customAbbreviation=mController.dayAbbreviationForDay(day.get(Calendar.DAY_OF_WEEK));
+        if (customAbbreviation!=null){
+            return customAbbreviation;
+        }else{
+            Locale locale = Locale.getDefault();
+            // Localised short version of the string is not available on API < 18
+            if (Build.VERSION.SDK_INT < 18) {
+                String dayName = new SimpleDateFormat("E", locale).format(day.getTime());
+                String dayLabel = dayName.toUpperCase(locale).substring(0, 1);
 
-        // Localised short version of the string is not available on API < 18
-        if(Build.VERSION.SDK_INT < 18) {
-            String dayName = new SimpleDateFormat("E", locale).format(day.getTime());
-            String dayLabel = dayName.toUpperCase(locale).substring(0, 1);
-
-            // Chinese labels should be fetched right to left
-            if (locale.equals(Locale.CHINA) || locale.equals(Locale.CHINESE) || locale.equals(Locale.SIMPLIFIED_CHINESE) || locale.equals(Locale.TRADITIONAL_CHINESE)) {
-                int len = dayName.length();
-                dayLabel = dayName.substring(len -1, len);
-            }
-
-            // Most hebrew labels should select the second to last character
-            if (locale.getLanguage().equals("he") || locale.getLanguage().equals("iw")) {
-                if(mDayLabelCalendar.get(Calendar.DAY_OF_WEEK) != Calendar.SATURDAY) {
+                // Chinese labels should be fetched right to left
+                if (locale.equals(Locale.CHINA) || locale.equals(Locale.CHINESE) || locale.equals(Locale.SIMPLIFIED_CHINESE) || locale.equals(Locale.TRADITIONAL_CHINESE)) {
                     int len = dayName.length();
-                    dayLabel = dayName.substring(len - 2, len - 1);
+                    dayLabel = dayName.substring(len - 1, len);
                 }
-                else {
-                    // I know this is duplication, but it makes the code easier to grok by
-                    // having all hebrew code in the same block
-                    dayLabel = dayName.toUpperCase(locale).substring(0, 1);
+
+                // Most hebrew labels should select the second to last character
+                if (locale.getLanguage().equals("he") || locale.getLanguage().equals("iw")) {
+                    if (mDayLabelCalendar.get(Calendar.DAY_OF_WEEK) != Calendar.SATURDAY) {
+                        int len = dayName.length();
+                        dayLabel = dayName.substring(len - 2, len - 1);
+                    } else {
+                        // I know this is duplication, but it makes the code easier to grok by
+                        // having all hebrew code in the same block
+                        dayLabel = dayName.toUpperCase(locale).substring(0, 1);
+                    }
                 }
+
+                // Catalan labels should be two digits in lowercase
+                if (locale.getLanguage().equals("ca"))
+                    dayLabel = dayName.toLowerCase().substring(0, 2);
+
+                // Correct single character label in Spanish is X
+                if (locale.getLanguage().equals("es") && day.get(Calendar.DAY_OF_WEEK) == Calendar.WEDNESDAY)
+                    dayLabel = "X";
+
+                return dayLabel;
             }
-
-            // Catalan labels should be two digits in lowercase
-            if (locale.getLanguage().equals("ca"))
-                dayLabel = dayName.toLowerCase().substring(0,2);
-
-            // Correct single character label in Spanish is X
-            if (locale.getLanguage().equals("es") && day.get(Calendar.DAY_OF_WEEK) == Calendar.WEDNESDAY)
-                dayLabel = "X";
-
-            return dayLabel;
+            // Getting the short label is a one liner on API >= 18
+            return new SimpleDateFormat("EEEEE", locale).format(day.getTime());
         }
-        // Getting the short label is a one liner on API >= 18
-        return new SimpleDateFormat("EEEEE", locale).format(day.getTime());
     }
 
     /**


### PR DESCRIPTION
Hi!

I implemented a solution so anyone can customize the day abbreviations, this could be helpful for some locales that gives us wrong abbreviations, in my case the "es_MX" locale is not available in every device so the locale give us a wrong abbreviation for Wednesday="X" instead of "M".

Please check the code and if there's all correct I hope you can add it to your library, it will help me a lot!!

Thank you!

I send you two screenshots of my tests.


![customabbreviations](https://cloud.githubusercontent.com/assets/6267487/20240720/1c5d88be-a8e5-11e6-87d3-b00da074ad42.png)
![localeabbreviations](https://cloud.githubusercontent.com/assets/6267487/20240721/1c634466-a8e5-11e6-8579-5e0ead3b8c52.png)
