### PR TITLE
Remove loud log statements

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -1123,7 +1123,6 @@ public class TimePickerDialog extends DialogFragment implements
             int currentDistance = Integer.MAX_VALUE;
             Timepoint output = time;
             for(Timepoint t : mSelectableTimes) {
-                Log.d("Timepoing", "" +  type + " " + time + " compared to " + t.toString());
                 // type == null: no restrictions
                 // type == HOUR: do not change the hour
                 if (type == Timepoint.TYPE.HOUR && t.getHour() != time.getHour()) continue;
@@ -1131,7 +1130,6 @@ public class TimePickerDialog extends DialogFragment implements
                 if (type == Timepoint.TYPE.MINUTE  && t.getHour() != time.getHour() && t.getMinute() != time.getMinute()) continue;
                 // type == SECOND: cannot change anything, return input
                 if (type == Timepoint.TYPE.SECOND) return time;
-                Log.d("Timepoing", "Comparing");
                 int newDistance = Math.abs(t.compareTo(time));
                 if (newDistance < currentDistance) {
                     currentDistance = newDistance;


### PR DESCRIPTION
With these log statements in place, if we use `setTimeInterval()` the logs will blow up so fast that the UI will actually hang.