### PR TITLE
Remove need for synthetic accessor methods.

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/GravitySnapHelper.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/GravitySnapHelper.java
@@ -39,8 +39,8 @@ public class GravitySnapHelper extends LinearSnapHelper {
     private OrientationHelper horizontalHelper;
     private int gravity;
     private boolean isRtlHorizontal;
-    private GravitySnapHelper.SnapListener listener;
-    private boolean snapping;
+    GravitySnapHelper.SnapListener listener;
+    boolean snapping;
     private RecyclerView.OnScrollListener mScrollListener = new RecyclerView.OnScrollListener() {
         @Override
         public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
@@ -247,7 +247,7 @@ public class GravitySnapHelper extends LinearSnapHelper {
         return null;
     }
 
-    private int getSnappedPosition(RecyclerView recyclerView) {
+    int getSnappedPosition(RecyclerView recyclerView) {
         RecyclerView.LayoutManager layoutManager = recyclerView.getLayoutManager();
 
         if (layoutManager instanceof LinearLayoutManager) {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/HapticFeedbackController.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/HapticFeedbackController.java
@@ -16,16 +16,16 @@ public class HapticFeedbackController {
     private static final int VIBRATE_DELAY_MS = 125;
     private static final int VIBRATE_LENGTH_MS = 50;
 
-    private static boolean checkGlobalSetting(Context context) {
+    static boolean checkGlobalSetting(Context context) {
         return Settings.System.getInt(context.getContentResolver(),
                 Settings.System.HAPTIC_FEEDBACK_ENABLED, 0) == 1;
     }
 
-    private final Context mContext;
+    final Context mContext;
     private final ContentObserver mContentObserver;
 
     private Vibrator mVibrator;
-    private boolean mIsGloballyEnabled;
+    boolean mIsGloballyEnabled;
     private long mLastVibrate;
 
     public HapticFeedbackController(Context context) {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/MonthView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/MonthView.java
@@ -514,7 +514,7 @@ public abstract class MonthView extends View {
      *
      * @param day The day that was clicked
      */
-    private void onDayClick(int day) {
+    void onDayClick(int day) {
         // If the min / max date are set, only process the click if it's a valid selection.
         if (mController.isOutOfRange(mYear, mMonth, day)) {
             return;

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/YearPickerView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/YearPickerView.java
@@ -38,11 +38,11 @@ import com.wdullaer.materialdatetimepicker.date.DatePickerDialog.OnDateChangedLi
 public class YearPickerView extends ListView implements OnItemClickListener, OnDateChangedListener {
     private static final String TAG = "YearPickerView";
 
-    private final DatePickerController mController;
+    final DatePickerController mController;
     private YearAdapter mAdapter;
     private int mViewSize;
     private int mChildSize;
-    private TextViewWithCircularIndicator mSelectedView;
+    TextViewWithCircularIndicator mSelectedView;
 
     public YearPickerView(Context context, DatePickerController controller) {
         super(context);

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialPickerLayout.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialPickerLayout.java
@@ -64,17 +64,17 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
     private static final int AM = TimePickerDialog.AM;
     private static final int PM = TimePickerDialog.PM;
 
-    private Timepoint mLastValueSelected;
+    Timepoint mLastValueSelected;
 
-    private TimePickerController mController;
-    private OnValueSelectedListener mListener;
+    TimePickerController mController;
+    OnValueSelectedListener mListener;
     private boolean mTimeInitialized;
-    private Timepoint mCurrentTime;
-    private boolean mIs24HourMode;
+    Timepoint mCurrentTime;
+    boolean mIs24HourMode;
     private int mCurrentItemShowing;
 
     private CircleView mCircleView;
-    private AmPmCirclesView mAmPmCirclesView;
+    AmPmCirclesView mAmPmCirclesView;
     private RadialTextsView mHourRadialTextsView;
     private RadialTextsView mMinuteRadialTextsView;
     private RadialTextsView mSecondRadialTextsView;
@@ -85,10 +85,10 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
 
     private int[] mSnapPrefer30sMap;
     private boolean mInputEnabled;
-    private int mIsTouchingAmOrPm = -1;
-    private boolean mDoingMove;
+    int mIsTouchingAmOrPm = -1;
+    boolean mDoingMove;
     private boolean mDoingTouch;
-    private int mDownDegrees;
+    int mDownDegrees;
     private float mDownX;
     private float mDownY;
     private AccessibilityManager mAccessibilityManager;
@@ -432,7 +432,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
      * @param currentItemShowing int - The index of the current view
      * @return Timepoint - the rounded value
      */
-    private Timepoint roundToValidTime(Timepoint newSelection, int currentItemShowing) {
+    Timepoint roundToValidTime(Timepoint newSelection, int currentItemShowing) {
         switch(currentItemShowing) {
             case HOUR_INDEX:
                 newSelection = mController.roundToNearest(newSelection, Timepoint.TYPE.HOUR);
@@ -458,7 +458,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
      * @param index The picker to use as a reference. Will be getCurrentItemShow() except when AM/PM is changed
      * is on non-visible values, but use this to force the dot to be shown.
      */
-    private void reselectSelector(Timepoint newSelection, boolean forceDrawDot, int index) {
+    void reselectSelector(Timepoint newSelection, boolean forceDrawDot, int index) {
         switch(index) {
             case HOUR_INDEX:
                 // The selection might have changed, recalculate the degrees and innerCircle values
@@ -519,7 +519,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
         }
     }
 
-    private Timepoint getTimeFromDegrees(int degrees, boolean isInnerCircle, boolean forceToVisibleValue) {
+    Timepoint getTimeFromDegrees(int degrees, boolean isInnerCircle, boolean forceToVisibleValue) {
         if (degrees == -1) {
             return null;
         }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -120,7 +120,7 @@ public class TimePickerDialog extends DialogFragment implements
     private TextView mAmTextView;
     private TextView mPmTextView;
     private View mAmPmLayout;
-    private RadialPickerLayout mTimePicker;
+    RadialPickerLayout mTimePicker;
 
     private int mSelectedColor;
     private int mUnselectedColor;
@@ -153,7 +153,7 @@ public class TimePickerDialog extends DialogFragment implements
     private char mPlaceholderText;
     private String mDoublePlaceholderText;
     private String mDeletedKeyFormat;
-    private boolean mInKbMode;
+    boolean mInKbMode;
     private ArrayList<Integer> mTypedTimes;
     private Node mLegalTimesTree;
     private int mAmKeyCode;
@@ -1186,7 +1186,7 @@ public class TimePickerDialog extends DialogFragment implements
     }
 
     // Show either Hours or Minutes.
-    private void setCurrentItemShowing(int index, boolean animateCircle, boolean delayLabelAnimate,
+    void setCurrentItemShowing(int index, boolean animateCircle, boolean delayLabelAnimate,
             boolean announce) {
         mTimePicker.setCurrentItemShowing(index, animateCircle);
 
@@ -1239,7 +1239,7 @@ public class TimePickerDialog extends DialogFragment implements
      * @param keyCode the pressed key.
      * @return true if the key was successfully processed, false otherwise.
      */
-    private boolean processKeyUp(int keyCode) {
+    boolean processKeyUp(int keyCode) {
         if (keyCode == KeyEvent.KEYCODE_ESCAPE || keyCode == KeyEvent.KEYCODE_BACK) {
             if(isCancelable()) dismiss();
             return true;


### PR DESCRIPTION
To access private fields and methods, the compiler adds static methods. These methods are just bloat.
For some more descriptions: https://news.realm.io/news/360andev-jake-wharton-java-hidden-costs-android/