### PR TITLE
Add hashCode() to Timepoint

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/Timepoint.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/Timepoint.java
@@ -5,6 +5,8 @@ import android.os.Parcelable;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 
+import java.util.Objects;
+
 /**
  * Simple utility class that represents a time in the day up to second precision
  * The time input is expected to use 24 hour mode.
@@ -83,17 +85,21 @@ public class Timepoint implements Parcelable, Comparable<Timepoint> {
     }
 
     @Override
-    public boolean equals(Object o) {
-        try {
-            Timepoint other = (Timepoint) o;
+    public int hashCode() {
+        int result = hour;
+        result = 31 * result + minute;
+        result = 31 * result + second;
+        return result;
+    }
 
-            return other.getHour() == hour &&
-                    other.getMinute() == minute &&
-                    other.getSecond() == second;
-        }
-        catch(ClassCastException e) {
-            return false;
-        }
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Timepoint timepoint = (Timepoint) o;
+
+        return hour == timepoint.hour && minute == timepoint.minute && second == timepoint.second;
     }
 
     @Override

--- a/library/src/test/java/com/wdullaer/materialdatetimepicker/date/TimepointTest.java
+++ b/library/src/test/java/com/wdullaer/materialdatetimepicker/date/TimepointTest.java
@@ -1,0 +1,47 @@
+package com.wdullaer.materialdatetimepicker.date;
+
+
+import com.wdullaer.materialdatetimepicker.time.Timepoint;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimepointTest {
+
+    @Test
+    public void timepointsWithSameFieldsShouldHaveSameHashCode() {
+        Timepoint first = new Timepoint(12, 0, 0);
+        Timepoint second = new Timepoint(12, 0, 0);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+
+    @Test
+    public void timepointsWithSameFieldsShouldBeEquals() {
+        Timepoint first = new Timepoint(12, 0, 0);
+        Timepoint second = new Timepoint(12, 0, 0);
+        assertEquals(first, second);
+    }
+
+    @Test
+    public void timepointsWithSameFieldsShouldBeDistinctInHashSet() {
+        HashSet<Timepoint> timepoints = new HashSet<>(4);
+        timepoints.add(new Timepoint(12, 0, 0));
+        timepoints.add(new Timepoint(12, 0, 0));
+        timepoints.add(new Timepoint(12, 0, 0));
+        timepoints.add(new Timepoint(12, 0, 0));
+        assertEquals(timepoints.size(), 1);
+    }
+
+    @Test
+    public void timepointsWithDifferentFieldsShouldNotBeDistinctInHashSet() {
+        HashSet<Timepoint> timepoints = new HashSet<>(4);
+        timepoints.add(new Timepoint(12, 1, 0));
+        timepoints.add(new Timepoint(12, 2, 0));
+        timepoints.add(new Timepoint(12, 3, 0));
+        timepoints.add(new Timepoint(12, 4, 0));
+        assertEquals(timepoints.size(), 4);
+    }
+}


### PR DESCRIPTION
Small improvement for Timepoint class. 
There is a problem when `setSelectableTimes()` called with equal timepoints TimePickerDialog becomes broken (part of available time can't be chosen). It can be fixed with `distinct()` call that available in different libraries or with HashSet, but because of hashCode() isn't implemented all hash-based collections work wrong.