### PR TITLE
Avoid enum

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/CircleView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/CircleView.java
@@ -65,7 +65,7 @@ public class CircleView extends View {
         mPaint.setAntiAlias(true);
 
         mIs24HourMode = controller.is24HourMode();
-        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.Version.VERSION_1) {
+        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.VERSION_1) {
             mCircleRadiusMultiplier = Float.parseFloat(
                     res.getString(R.string.mdtp_circle_radius_multiplier_24HourMode));
         } else {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialPickerLayout.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialPickerLayout.java
@@ -173,7 +173,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
         // Initialize the circle and AM/PM circles if applicable.
         mCircleView.initialize(context, mController);
         mCircleView.invalidate();
-        if (!mIs24HourMode && mController.getVersion() == TimePickerDialog.Version.VERSION_1) {
+        if (!mIs24HourMode && mController.getVersion() == TimePickerDialog.VERSION_1) {
             mAmPmCirclesView.initialize(context, mController, initialTime.isAM() ? AM : PM);
             mAmPmCirclesView.invalidate();
         }
@@ -435,11 +435,11 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
     private Timepoint roundToValidTime(Timepoint newSelection, int currentItemShowing) {
         switch(currentItemShowing) {
             case HOUR_INDEX:
-                return mController.roundToNearest(newSelection, null);
+                return mController.roundToNearest(newSelection, Timepoint.NONE);
             case MINUTE_INDEX:
-                return mController.roundToNearest(newSelection, Timepoint.TYPE.HOUR);
+                return mController.roundToNearest(newSelection, Timepoint.HOUR);
             default:
-                return mController.roundToNearest(newSelection, Timepoint.TYPE.MINUTE);
+                return mController.roundToNearest(newSelection, Timepoint.MINUTE);
         }
     }
 
@@ -718,7 +718,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
                 mDoingMove = false;
                 mDoingTouch = true;
                 // If we're showing the AM/PM, check to see if the user is touching it.
-                if (!mIs24HourMode && mController.getVersion() == TimePickerDialog.Version.VERSION_1) {
+                if (!mIs24HourMode && mController.getVersion() == TimePickerDialog.VERSION_1) {
                     mIsTouchingAmOrPm = mAmPmCirclesView.getIsTouchingAmOrPm(eventX, eventY);
                 } else {
                     mIsTouchingAmOrPm = -1;

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialSelectorView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialSelectorView.java
@@ -108,7 +108,7 @@ public class RadialSelectorView extends View {
 
         // Calculate values for the circle radius size.
         mIs24HourMode = controller.is24HourMode();
-        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.Version.VERSION_1) {
+        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.VERSION_1) {
             mCircleRadiusMultiplier = Float.parseFloat(
                     res.getString(R.string.mdtp_circle_radius_multiplier_24HourMode));
         } else {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialTextsView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialTextsView.java
@@ -123,7 +123,7 @@ public class RadialTextsView extends View {
         mHasInnerCircle = (innerTexts != null);
 
         // Calculate the radius for the main circle.
-        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.Version.VERSION_1) {
+        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.VERSION_1) {
             mCircleRadiusMultiplier = Float.parseFloat(
                     res.getString(R.string.mdtp_circle_radius_multiplier_24HourMode));
         } else {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerController.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerController.java
@@ -24,7 +24,7 @@ public interface TimePickerController {
     /**
      * @return Version - The current version to render
      */
-    TimePickerDialog.Version getVersion();
+    @TimePickerDialog.Version int getVersion();
 
     /**
      * Request the device to vibrate
@@ -57,5 +57,5 @@ public interface TimePickerController {
      * @param type Timepoint.TYPE - whether we should round the hours, minutes or seconds
      * @return timepoint - the nearest valid timepoint
      */
-    Timepoint roundToNearest(Timepoint time, Timepoint.TYPE type);
+    Timepoint roundToNearest(Timepoint time, @Timepoint.type int type);
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/Timepoint.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/Timepoint.java
@@ -2,8 +2,12 @@ package com.wdullaer.materialdatetimepicker.time;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.IntDef;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
  * Simple utility class that represents a time in the day up to second precision
@@ -19,11 +23,29 @@ public class Timepoint implements Parcelable, Comparable<Timepoint> {
     private int minute;
     private int second;
 
-    public enum TYPE {
-        HOUR,
-        MINUTE,
-        SECOND
-    }
+    /**
+     * No type
+     */
+    public static final int NONE = 0;
+    /**
+     * Hour type
+     */
+    public static final int HOUR = 1;
+    /**
+     * Minute type
+     */
+    public static final int MINUTE = 2;
+    /**
+     * Second type
+     */
+    public static final int SECOND = 3;
+
+    /**
+     * Type of HOUR, MINUTE, SECOND
+     */
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({HOUR, MINUTE, SECOND, NONE})
+    public @interface type{}
 
     public Timepoint(Timepoint time) {
         this(time.hour, time.minute, time.second);

--- a/sample/src/main/java/com/wdullaer/datetimepickerexample/DatePickerFragment.java
+++ b/sample/src/main/java/com/wdullaer/datetimepickerexample/DatePickerFragment.java
@@ -68,7 +68,7 @@ public class DatePickerFragment extends Fragment implements DatePickerDialog.OnD
                 dpd.vibrate(vibrateDate.isChecked());
                 dpd.dismissOnPause(dismissDate.isChecked());
                 dpd.showYearPickerFirst(showYearFirst.isChecked());
-                dpd.setVersion(showVersion2.isChecked() ? DatePickerDialog.Version.VERSION_2 : DatePickerDialog.Version.VERSION_1);
+                dpd.setVersion(showVersion2.isChecked() ? DatePickerDialog.VERSION_2 : DatePickerDialog.VERSION_1);
                 if (modeCustomAccentDate.isChecked()) {
                     dpd.setAccentColor(Color.parseColor("#9C27B0"));
                 }

--- a/sample/src/main/java/com/wdullaer/datetimepickerexample/TimePickerFragment.java
+++ b/sample/src/main/java/com/wdullaer/datetimepickerexample/TimePickerFragment.java
@@ -69,7 +69,7 @@ public class TimePickerFragment extends Fragment implements TimePickerDialog.OnT
                 tpd.vibrate(vibrateTime.isChecked());
                 tpd.dismissOnPause(dismissTime.isChecked());
                 tpd.enableSeconds(enableSeconds.isChecked());
-                tpd.setVersion(showVersion2.isChecked() ? TimePickerDialog.Version.VERSION_2 : TimePickerDialog.Version.VERSION_1);
+                tpd.setVersion(showVersion2.isChecked() ? TimePickerDialog.VERSION_2 : TimePickerDialog.VERSION_1);
                 if (modeCustomAccentTime.isChecked()) {
                     tpd.setAccentColor(Color.parseColor("#9C27B0"));
                 }


### PR DESCRIPTION
Using enum will increase dex size and increase runtime memory allocation size.
reference: https://www.youtube.com/watch?v=Hzs6OBcvNQE

solution for replace enum is using intDef
public static final int VERSION_1 = 0;
public static final int VERSION_2 = 1;

@retention(RetentionPolicy.SOURCE)
@intdef({VERSION_1, VERSION_2})
public @interface Version{}