### PR TITLE
Make OnDateChangedListener interface public

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0-rc01'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -181,7 +181,6 @@ public class DatePickerDialog extends DialogFragment implements
     /**
      * The callback used to notify other date picker components of a change in selected date.
      */
-    @SuppressWarnings("WeakerAccess")
     public interface OnDateChangedListener {
 
         void onDateChanged();

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -182,7 +182,7 @@ public class DatePickerDialog extends DialogFragment implements
      * The callback used to notify other date picker components of a change in selected date.
      */
     @SuppressWarnings("WeakerAccess")
-    protected interface OnDateChangedListener {
+    public interface OnDateChangedListener {
 
         void onDateChanged();
     }


### PR DESCRIPTION
Making this interface public will make the DatePickerController and the public accessible Views more flexible. Now DatePickerController is a public interface, but can't be implemented outside the project (due to the fact that it contains the protected DatePickerDialog.ONDateChangedListener).

Proposition: The OnDateChangedListener could even be a seperate public interface instead of an interface inside DatePickerDialog