### PR TITLE
Add Nordic da, fi, nb, sv translations to next/prev month accesibilty labels

### DIFF
--- a/library/src/main/res/values-da/strings.xml
+++ b/library/src/main/res/values-da/strings.xml
@@ -30,4 +30,6 @@
     <string name="mdtp_deleted_key" msgid="6908431551612331381">"<xliff:g id="KEY">%1$s</xliff:g> er slettet"</string>
     <string name="mdtp_date_v1_monthyear">MMMM yyyy</string>
     <string name="mdtp_date_v2_daymonthyear">EEE dd. MMM</string>
+    <string name="mdtp_next_month_arrow_description">Næste måned</string>
+    <string name="mdtp_previous_month_arrow_description">Foregående måned</string>
 </resources>

--- a/library/src/main/res/values-fi/strings.xml
+++ b/library/src/main/res/values-fi/strings.xml
@@ -30,4 +30,6 @@
     <string name="mdtp_deleted_key" msgid="6908431551612331381">"<xliff:g id="KEY">%1$s</xliff:g> poistettiin"</string>
     <string name="mdtp_date_v1_monthyear">LLLL yyyy</string>
     <string name="mdtp_date_v2_daymonthyear">ccc dd. MMM</string>
+    <string name="mdtp_next_month_arrow_description">Seuraava kuukausi</string>
+    <string name="mdtp_previous_month_arrow_description">Edellinen kuukausi</string>
 </resources>

--- a/library/src/main/res/values-nb/strings.xml
+++ b/library/src/main/res/values-nb/strings.xml
@@ -30,4 +30,6 @@
     <string name="mdtp_deleted_key" msgid="6908431551612331381">"<xliff:g id="KEY">%1$s</xliff:g> er slettet"</string>
     <string name="mdtp_date_v1_monthyear">MMMM yyyy</string>
     <string name="mdtp_date_v2_daymonthyear">EEE dd. MMM</string>
+    <string name="mdtp_next_month_arrow_description">Neste måned</string>
+    <string name="mdtp_previous_month_arrow_description">Forrige måned</string>
 </resources>

--- a/library/src/main/res/values-sv/strings.xml
+++ b/library/src/main/res/values-sv/strings.xml
@@ -30,4 +30,6 @@
     <string name="mdtp_deleted_key" msgid="6908431551612331381">"<xliff:g id="KEY">%1$s</xliff:g> har tagits bort"</string>
     <string name="mdtp_date_v1_monthyear">MMMM yyyy</string>
     <string name="mdtp_date_v2_daymonthyear">EEE dd MMM</string>
+    <string name="mdtp_next_month_arrow_description">Nästä månad</string>
+    <string name="mdtp_previous_month_arrow_description">Föregående månad</string>
 </resources>


### PR DESCRIPTION
Did some language testing on the talkback stuff in #550 and noticed these labels are not translated everywhere. Added translations for the Nordic languages I am able to help with.