### PR TITLE
NPE fix: DayPickerView accessibilityAnnouncePageChanged()

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DayPickerView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DayPickerView.java
@@ -355,8 +355,10 @@ public abstract class DayPickerView extends RecyclerView implements OnDateChange
 
     void accessibilityAnnouncePageChanged() {
         MonthView mv = getMostVisibleMonth();
-        String monthYear = getMonthAndYearString(mv.mMonth, mv.mYear, mController.getLocale());
-        Utils.tryAccessibilityAnnounce(this, monthYear);
+        if (mv != null) {
+            String monthYear = getMonthAndYearString(mv.mMonth, mv.mYear, mController.getLocale());
+            Utils.tryAccessibilityAnnounce(this, monthYear);
+        }
     }
 
     private static String getMonthAndYearString(int month, int year, Locale locale) {


### PR DESCRIPTION
No repro steps known but observed in crash reports:

```
java.lang.NullPointerException: Attempt to read from field 'int com.wdullaer.materialdatetimepicker.date.f.q' on a null object reference
	at com.wdullaer.materialdatetimepicker.date.DayPickerView.accessibilityAnnouncePageChanged(DayPickerView.java:358)
	at com.wdullaer.materialdatetimepicker.date.DayPickerGroup.onPageChanged(DayPickerGroup.java:165)
	at com.wdullaer.materialdatetimepicker.date.DayPickerView.lambda$postSetSelection$1(DayPickerView.java:243)
	at com.wdullaer.materialdatetimepicker.date.DayPickerView.lambda$8F5oU5Xu0TCRqOvDcyASTMEj6VU(DayPickerView.java)
	at com.wdullaer.materialdatetimepicker.date.-$$Lambda$DayPickerView$8F5oU5Xu0TCRqOvDcyASTMEj6VU.run(-.java)
```

Considering avoiding NPE more important than missing an accessibility announcement.