### PR TITLE
Remove unused code

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -477,13 +477,6 @@ public class DatePickerDialog extends AppCompatDialogFragment implements
         }
     }
 
-    @Override @NonNull
-    public Dialog onCreateDialog(Bundle savedInstanceState) {
-        Dialog dialog = super.onCreateDialog(savedInstanceState);
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
-        return dialog;
-    }
-
     @Override
     public void onResume() {
         super.onResume();

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -1019,13 +1019,6 @@ public class TimePickerDialog extends AppCompatDialogFragment implements
         }
     }
 
-    @Override @NonNull
-    public Dialog onCreateDialog(Bundle savedInstanceState) {
-        Dialog dialog = super.onCreateDialog(savedInstanceState);
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
-        return dialog;
-    }
-
     @Override
     public void onResume() {
         super.onResume();


### PR DESCRIPTION
In `v4.2.1` has called `setStyle`.
So we don't need to override `onCreateDialog` anymore.