### PR TITLE
Added ES, US_ES, IT and PT translations for next and previous labels

### DIFF
--- a/library/src/main/res/values-es-rUS/strings.xml
+++ b/library/src/main/res/values-es-rUS/strings.xml
@@ -30,4 +30,6 @@
     <string name="mdtp_deleted_key" msgid="6908431551612331381">"<xliff:g id="KEY">%1$s</xliff:g> borrado"</string>
     <string name="mdtp_date_v1_monthyear">MMMM \'de\' yyyy</string>
     <string name="mdtp_date_v2_daymonthyear">EEE dd \'de\' MMM</string>
+    <string name="mdtp_next_month_arrow_description">Pŕoximo Mes</string>
+    <string name="mdtp_previous_month_arrow_description">Mes Previo</string>
 </resources>

--- a/library/src/main/res/values-es/strings.xml
+++ b/library/src/main/res/values-es/strings.xml
@@ -30,4 +30,6 @@
     <string name="mdtp_deleted_key" msgid="6908431551612331381">"<xliff:g id="KEY">%1$s</xliff:g> eliminado"</string>
     <string name="mdtp_date_v1_monthyear">MMMM \'de\' yyyy</string>
     <string name="mdtp_date_v2_daymonthyear">EEE dd \'de\' MMM</string>
+    <string name="mdtp_next_month_arrow_description">Pŕoximo Mes</string>
+    <string name="mdtp_previous_month_arrow_description">Mes Previo</string>
 </resources>

--- a/library/src/main/res/values-it/strings.xml
+++ b/library/src/main/res/values-it/strings.xml
@@ -30,4 +30,6 @@
     <string name="mdtp_deleted_key" msgid="6908431551612331381">"<xliff:g id="KEY">%1$s</xliff:g> eliminato"</string>
     <string name="mdtp_date_v1_monthyear">MMMM yyyy</string>
     <string name="mdtp_date_v2_daymonthyear">EEE dd MMM</string>
+    <string name="mdtp_next_month_arrow_description">Prossimo mese</string>
+    <string name="mdtp_previous_month_arrow_description">Mese precedente</string>
 </resources>

--- a/library/src/main/res/values-pt-rPT/strings.xml
+++ b/library/src/main/res/values-pt-rPT/strings.xml
@@ -30,4 +30,6 @@
     <string name="mdtp_deleted_key" msgid="6908431551612331381">"<xliff:g id="KEY">%1$s</xliff:g> eliminado"</string>
     <string name="mdtp_date_v1_monthyear">MMMM \'de\' yyyy</string>
     <string name="mdtp_date_v2_daymonthyear">EEE, dd \'de\' MMM</string>
+    <string name="mdtp_next_month_arrow_description">Próximo Mês</string>
+    <string name="mdtp_previous_month_arrow_description">Mês Anterior</string>
 </resources>

--- a/library/src/main/res/values-pt/strings.xml
+++ b/library/src/main/res/values-pt/strings.xml
@@ -30,4 +30,6 @@
     <string name="mdtp_deleted_key" msgid="6908431551612331381">"<xliff:g id="KEY">%1$s</xliff:g> excluído"</string>
     <string name="mdtp_date_v1_monthyear">MMMM \'de\' yyyy</string>
     <string name="mdtp_date_v2_daymonthyear">EEE, dd \'de\' MMM</string>
+    <string name="mdtp_next_month_arrow_description">Próximo Mês</string>
+    <string name="mdtp_previous_month_arrow_description">Mês Anterior</string>
 </resources>


### PR DESCRIPTION
Added Spanish, Spanish used in the US, Italian and Portuguese translations for the next and previous labels