### PR TITLE
Make TalkBack only read values that've changed when in "accessibility mode" #617

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/Utils.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/Utils.java
@@ -62,7 +62,7 @@ public class Utils {
      * @return The animator object. Use .start() to begin.
      */
     public static ObjectAnimator getPulseAnimator(View labelToAnimate, float decreaseRatio,
-                                                  float increaseRatio) {
+            float increaseRatio) {
         Keyframe k0 = Keyframe.ofFloat(0f, 1f);
         Keyframe k1 = Keyframe.ofFloat(0.275f, decreaseRatio);
         Keyframe k2 = Keyframe.ofFloat(0.69f, increaseRatio);

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/Utils.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/Utils.java
@@ -62,7 +62,7 @@ public class Utils {
      * @return The animator object. Use .start() to begin.
      */
     public static ObjectAnimator getPulseAnimator(View labelToAnimate, float decreaseRatio,
-            float increaseRatio) {
+                                                  float increaseRatio) {
         Keyframe k0 = Keyframe.ofFloat(0f, 1f);
         Keyframe k1 = Keyframe.ofFloat(0.275f, decreaseRatio);
         Keyframe k2 = Keyframe.ofFloat(0.69f, increaseRatio);
@@ -153,5 +153,19 @@ public class Utils {
         calendar.set(Calendar.SECOND, 0);
         calendar.set(Calendar.MILLISECOND, 0);
         return calendar;
+    }
+
+    /**
+     * Cast string to int
+     *
+     * @param text The text to convert to an int
+     * @return the parsed value or -1
+     */
+    public static int stringToInt(String text) {
+        try {
+            return Integer.parseInt(text);
+        } catch (NumberFormatException exception) {
+            return -1;
+        }
     }
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -792,6 +792,11 @@ public class TimePickerDialog extends AppCompatDialogFragment implements
                     amOrPm = AM;
                 }
                 mTimePicker.setAmOrPm(amOrPm);
+                if (amOrPm == AM) {
+                    Utils.tryAccessibilityAnnounce(mTimePicker, mAmText);
+                } else if (amOrPm == PM) {
+                    Utils.tryAccessibilityAnnounce(mTimePicker, mPmText);
+                }
             };
             mAmTextView .setVisibility(View.GONE);
             mPmTextView.setVisibility(View.VISIBLE);
@@ -1055,20 +1060,16 @@ public class TimePickerDialog extends AppCompatDialogFragment implements
             if (amOrPm == AM) {
                 mAmTextView.setTextColor(mSelectedColor);
                 mPmTextView.setTextColor(mUnselectedColor);
-                Utils.tryAccessibilityAnnounce(mTimePicker, mAmText);
             } else {
                 mAmTextView.setTextColor(mUnselectedColor);
                 mPmTextView.setTextColor(mSelectedColor);
-                Utils.tryAccessibilityAnnounce(mTimePicker, mPmText);
             }
         } else {
             if (amOrPm == AM) {
                 mPmTextView.setText(mAmText);
-                Utils.tryAccessibilityAnnounce(mTimePicker, mAmText);
                 mPmTextView.setContentDescription(mAmText);
             } else if (amOrPm == PM){
                 mPmTextView.setText(mPmText);
-                Utils.tryAccessibilityAnnounce(mTimePicker, mPmText);
                 mPmTextView.setContentDescription(mPmText);
             } else {
                 mPmTextView.setText(mDoublePlaceholderText);
@@ -1111,7 +1112,7 @@ public class TimePickerDialog extends AppCompatDialogFragment implements
      */
     @Override
     public void onValueSelected(Timepoint newValue) {
-        setHour(newValue.getHour(), false);
+        setHour(newValue.getHour(), true);
         mTimePicker.setContentDescription(mHourPickerDescription + ": " + newValue.getHour());
         setMinute(newValue.getMinute());
         mTimePicker.setContentDescription(mMinutePickerDescription + ": " + newValue.getMinute());
@@ -1126,12 +1127,12 @@ public class TimePickerDialog extends AppCompatDialogFragment implements
         if(index == HOUR_INDEX && mEnableMinutes) {
             setCurrentItemShowing(MINUTE_INDEX, true, true, false);
 
-            String announcement = mSelectHours + ". " + mTimePicker.getMinutes();
+            String announcement = mSelectMinutes + ". " + mTimePicker.getMinutes();
             Utils.tryAccessibilityAnnounce(mTimePicker, announcement);
         } else if(index == MINUTE_INDEX && mEnableSeconds) {
             setCurrentItemShowing(SECOND_INDEX, true, true, false);
 
-            String announcement = mSelectMinutes+". " + mTimePicker.getSeconds();
+            String announcement = mSelectSeconds +". " + mTimePicker.getSeconds();
             Utils.tryAccessibilityAnnounce(mTimePicker, announcement);
         }
     }
@@ -1198,9 +1199,10 @@ public class TimePickerDialog extends AppCompatDialogFragment implements
         }
 
         CharSequence text = String.format(mLocale, format, value);
+        int oldValue = Utils.stringToInt(mHourView.getText().toString());
         mHourView.setText(text);
         mHourSpaceView.setText(text);
-        if (announce) {
+        if (announce && oldValue != value && oldValue != -1) {
             Utils.tryAccessibilityAnnounce(mTimePicker, text);
         }
     }
@@ -1209,20 +1211,26 @@ public class TimePickerDialog extends AppCompatDialogFragment implements
         if (value == 60) {
             value = 0;
         }
+        int oldValue = Utils.stringToInt(mMinuteView.getText().toString());
         CharSequence text = String.format(mLocale, "%02d", value);
-        Utils.tryAccessibilityAnnounce(mTimePicker, text);
         mMinuteView.setText(text);
         mMinuteSpaceView.setText(text);
+        if (oldValue != value && oldValue != -1) {
+            Utils.tryAccessibilityAnnounce(mTimePicker, text);
+        }
     }
 
     private void setSecond(int value) {
         if(value == 60) {
             value = 0;
         }
+        int oldValue = Utils.stringToInt(mSecondView.getText().toString());
         CharSequence text = String.format(mLocale, "%02d", value);
-        Utils.tryAccessibilityAnnounce(mTimePicker, text);
         mSecondView.setText(text);
         mSecondSpaceView.setText(text);
+        if (oldValue != value && oldValue != -1) {
+            Utils.tryAccessibilityAnnounce(mTimePicker, text);
+        }
     }
 
     // Show either Hours or Minutes.


### PR DESCRIPTION
This PR improves what TalkBack reads when using your fingers to select hours/minutes/seconds. It'll now only read the value that's changed, similar to how the Google Clock app does it. 