### PR TITLE
upgraded Android Gradle Plugin version to the latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
~~By this change, when this library used as a submodule in another project, its AGP will not be used and the project will be built by the root project's AGP, in other words, this change avoids unnecessary AGP downloads and other conflicts like AGP versions mismatch between this module and root project.~~

~~for more info, you can read [this thread](https://github.com/facebook/react-native/pull/25569), specially [this comment](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277).~~