### PR TITLE
Added new method for replacing the disabled days, fixed tests

### DIFF
--- a/library/src/androidTest/java/com/wdullaer/materialdatetimepicker/date/DefaultDateRangeLimiterTest.java
+++ b/library/src/androidTest/java/com/wdullaer/materialdatetimepicker/date/DefaultDateRangeLimiterTest.java
@@ -97,7 +97,7 @@ public class DefaultDateRangeLimiterTest {
         };
 
         DefaultDateRangeLimiter limiter = new DefaultDateRangeLimiter();
-        limiter.setDisabledDays(disabledDays);
+        limiter.addDisabledDays(disabledDays);
 
         Parcel parcel = Parcel.obtain();
         limiter.writeToParcel(parcel, 0);
@@ -134,7 +134,7 @@ public class DefaultDateRangeLimiterTest {
         limiter.setYearRange(minYear, maxYear);
         limiter.setMinDate(minDate);
         limiter.setMaxDate(maxDate);
-        limiter.setDisabledDays(disabledDays);
+        limiter.addDisabledDays(disabledDays);
         limiter.setSelectableDays(selectableDays);
 
         Parcel parcel = Parcel.obtain();

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -856,13 +856,43 @@ public class DatePickerDialog extends AppCompatDialogFragment implements
 
     /**
      * Sets a list of days that are not selectable in the picker
+     * Setting this value will add the new disabled days to the existing disabled days
+     * Setting this value will take precedence over using setMinDate() and setMaxDate(), but stacks with setSelectableDays()
+     *
+     * @param disabledDays an Array of Calendar Objects containing the disabled dates
+     *
+     * @deprecated Because the method name could lead the user to interpret that the new disabled days replace the old ones
+     * <br/>Use {@link #addDisabledDays(Calendar[])} instead
+     */
+    @SuppressWarnings("unused")
+    @Deprecated
+    public void setDisabledDays(Calendar[] disabledDays) {
+        addDisabledDays(disabledDays);
+    }
+
+    /**
+     * Sets a list of days that are not selectable in the picker
+     * Setting this value will add the new disabled days to the existing disabled days
      * Setting this value will take precedence over using setMinDate() and setMaxDate(), but stacks with setSelectableDays()
      *
      * @param disabledDays an Array of Calendar Objects containing the disabled dates
      */
     @SuppressWarnings("unused")
-    public void setDisabledDays(Calendar[] disabledDays) {
-        mDefaultLimiter.setDisabledDays(disabledDays);
+    public void addDisabledDays(Calendar[] disabledDays) {
+        mDefaultLimiter.addDisabledDays(disabledDays);
+        if (mDayPickerView != null) mDayPickerView.onChange();
+    }
+
+    /**
+     * Sets a list of days that are not selectable in the picker
+     * Setting this value will replace the existing disabled days
+     * Setting this value will take precedence over using setMinDate() and setMaxDate(), but stacks with setSelectableDays()
+     *
+     * @param disabledDays an Array of Calendar Objects containing the disabled dates
+     */
+    @SuppressWarnings("unused")
+    public void replaceDisabledDays(Calendar[] disabledDays) {
+        mDefaultLimiter.replaceDisabledDays(disabledDays);
         if (mDayPickerView != null) mDayPickerView.onChange();
     }
 

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DefaultDateRangeLimiter.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DefaultDateRangeLimiter.java
@@ -25,6 +25,7 @@ import com.wdullaer.materialdatetimepicker.Utils;
 
 import java.util.Calendar;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.TimeZone;
 import java.util.TreeSet;
 
@@ -38,7 +39,7 @@ class DefaultDateRangeLimiter implements DateRangeLimiter {
     private Calendar mMinDate;
     private Calendar mMaxDate;
     private TreeSet<Calendar> selectableDays = new TreeSet<>();
-    private HashSet<Calendar> disabledDays = new HashSet<>();
+    private HashSet<Calendar> disabledDays = new LinkedHashSet<>();
 
     DefaultDateRangeLimiter() {}
 
@@ -85,10 +86,15 @@ class DefaultDateRangeLimiter implements DateRangeLimiter {
         }
     }
 
-    void setDisabledDays(@NonNull Calendar[] days) {
+    void addDisabledDays(@NonNull Calendar[] days) {
         for (Calendar disabledDay : days) {
             this.disabledDays.add(Utils.trimToMidnight((Calendar) disabledDay.clone()));
         }
+    }
+
+    void replaceDisabledDays(@NonNull Calendar[] days) {
+        this.disabledDays.clear();
+        addDisabledDays(days);
     }
 
     void setMinDate(@NonNull Calendar calendar) {

--- a/library/src/test/java/com/wdullaer/materialdatetimepicker/date/DefaultDateRangeLimiterPropertyTest.java
+++ b/library/src/test/java/com/wdullaer/materialdatetimepicker/date/DefaultDateRangeLimiterPropertyTest.java
@@ -156,7 +156,7 @@ public class DefaultDateRangeLimiterPropertyTest {
 
         Calendar[] disableds = datesToCalendars(dates);
 
-        limiter.setDisabledDays(disableds);
+        limiter.addDisabledDays(disableds);
         Assert.assertFalse(Arrays.asList(disableds).contains(limiter.setToNearestDate(day)));
     }
 

--- a/library/src/test/java/com/wdullaer/materialdatetimepicker/date/DefaultDateRangeLimiterTest.java
+++ b/library/src/test/java/com/wdullaer/materialdatetimepicker/date/DefaultDateRangeLimiterTest.java
@@ -146,7 +146,7 @@ public class DefaultDateRangeLimiterTest {
             days[i] = day;
         }
 
-        limiter.setDisabledDays(days);
+        limiter.addDisabledDays(days);
         Calendar[] disabledDays = limiter.getDisabledDays();
 
         Assert.assertNotNull(disabledDays);
@@ -332,7 +332,7 @@ public class DefaultDateRangeLimiterTest {
         day.set(Calendar.YEAR, 1999);
         days[0] = day;
 
-        limiter.setDisabledDays(days);
+        limiter.addDisabledDays(days);
         int year = day.get(Calendar.YEAR);
         int month = day.get(Calendar.MONTH);
         int dayNumber = day.get(Calendar.DAY_OF_MONTH);
@@ -427,7 +427,7 @@ public class DefaultDateRangeLimiterTest {
         days[0] = day;
 
         limiter.setSelectableDays(days);
-        limiter.setDisabledDays(days);
+        limiter.addDisabledDays(days);
         int year = day.get(Calendar.YEAR);
         int month = day.get(Calendar.MONTH);
         int dayNumber = day.get(Calendar.DAY_OF_MONTH);
@@ -539,7 +539,7 @@ public class DefaultDateRangeLimiterTest {
             }
         };
 
-        limiter.setDisabledDays(days);
+        limiter.addDisabledDays(days);
         limiter.setController(controller);
 
         Assert.assertTrue(limiter.isOutOfRange(year, month, day));
@@ -569,7 +569,7 @@ public class DefaultDateRangeLimiterTest {
             days[i] = day;
         }
 
-        limiter.setDisabledDays(days);
+        limiter.addDisabledDays(days);
         Calendar day = (Calendar) days[0].clone();
 
         Assert.assertNotSame(limiter.setToNearestDate(day).getTimeInMillis(), days[0].getTimeInMillis());
@@ -696,5 +696,75 @@ public class DefaultDateRangeLimiterTest {
                 Utils.trimToMidnight(expectedDay).getTimeInMillis(),
                 limiter.setToNearestDate(day).getTimeInMillis()
         );
+    }
+
+    @Test
+    public void addDisabledDaysShouldAddToExistingDates() {
+        DefaultDateRangeLimiter limiter = new DefaultDateRangeLimiter();
+        Calendar[] daysArrayOne = new Calendar[3];
+        for (int i = 0;i < daysArrayOne.length; i++) {
+            Calendar day = Calendar.getInstance();
+            day.set(Calendar.YEAR, 1999 + i);
+            day.set(Calendar.HOUR_OF_DAY, 2);
+            day.set(Calendar.MINUTE, 10);
+            day.set(Calendar.SECOND, 30);
+            day.set(Calendar.MILLISECOND, 25);
+            daysArrayOne[i] = day;
+        }
+        Calendar[] daysArrayTwo = new Calendar[3];
+        for (int i = 0;i < daysArrayTwo.length; i++) {
+            Calendar day = Calendar.getInstance();
+            day.set(Calendar.YEAR, 2005 + i);
+            day.set(Calendar.HOUR_OF_DAY, 4);
+            day.set(Calendar.MINUTE, 20);
+            day.set(Calendar.SECOND, 40);
+            day.set(Calendar.MILLISECOND, 50);
+            daysArrayTwo[i] = day;
+        }
+
+        limiter.addDisabledDays(daysArrayOne);
+        int previousDisabledDatesLength = limiter.getDisabledDays() != null ? limiter.getDisabledDays().length : 0;
+        Assert.assertEquals(daysArrayOne.length, previousDisabledDatesLength);
+
+        limiter.addDisabledDays(daysArrayTwo);
+
+        int newDisabledDatesLength = limiter.getDisabledDays() != null ? limiter.getDisabledDays().length : 0;
+        Assert.assertEquals(daysArrayTwo.length + daysArrayOne.length, newDisabledDatesLength);
+        Assert.assertTrue(previousDisabledDatesLength < newDisabledDatesLength);
+    }
+
+    @Test
+    public void replaceDisabledDaysShouldOverwriteExistingDates() {
+        DefaultDateRangeLimiter limiter = new DefaultDateRangeLimiter();
+        Calendar[] daysArrayOne = new Calendar[3];
+        for (int i = 0;i < daysArrayOne.length; i++) {
+            Calendar day = Calendar.getInstance();
+            day.set(Calendar.YEAR, 1999 + i);
+            day.set(Calendar.HOUR_OF_DAY, 2);
+            day.set(Calendar.MINUTE, 10);
+            day.set(Calendar.SECOND, 30);
+            day.set(Calendar.MILLISECOND, 25);
+            daysArrayOne[i] = day;
+        }
+        Calendar[] daysArrayTwo = new Calendar[3];
+        for (int i = 0;i < daysArrayTwo.length; i++) {
+            Calendar day = Calendar.getInstance();
+            day.set(Calendar.YEAR, 2005 + i);
+            day.set(Calendar.HOUR_OF_DAY, 4);
+            day.set(Calendar.MINUTE, 20);
+            day.set(Calendar.SECOND, 40);
+            day.set(Calendar.MILLISECOND, 50);
+            daysArrayTwo[i] = day;
+        }
+
+        limiter.replaceDisabledDays(daysArrayOne);
+        int previousDisabledDatesLength = limiter.getDisabledDays() != null ? limiter.getDisabledDays().length : 0;
+        Assert.assertEquals(daysArrayOne.length, previousDisabledDatesLength);
+
+        limiter.replaceDisabledDays(daysArrayTwo);
+
+        int newDisabledDatesLength = limiter.getDisabledDays() != null ? limiter.getDisabledDays().length : 0;
+        Assert.assertEquals(daysArrayTwo.length, newDisabledDatesLength);
+        Assert.assertEquals(previousDisabledDatesLength, newDisabledDatesLength);
     }
 }


### PR DESCRIPTION
- Added `replaceDisabledDates()` to replace existing disabled dates with a new array
- `shouldCorrectlySaveAndRestoreAParcelWithDisabledDays()` android test was failing because of random ordering of items in the cloned list, solution is to use LinkedHashSet to retain the ordering of the elements
- Added required tests for the new methods