### PR TITLE
Fix for loosing state on Android N after scren rotation

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -19,7 +19,6 @@ package com.wdullaer.materialdatetimepicker.date;
 import android.animation.ObjectAnimator;
 import android.app.Activity;
 import android.content.DialogInterface;
-import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Build;
@@ -464,17 +463,6 @@ public class DatePickerDialog extends AppCompatDialogFragment implements
 
         mHapticFeedbackController = new HapticFeedbackController(activity);
         return view;
-    }
-
-    @Override
-    public void onConfigurationChanged(final Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        ViewGroup viewGroup = (ViewGroup) getView();
-        if (viewGroup != null) {
-            viewGroup.removeAllViewsInLayout();
-            View view = onCreateView(requireActivity().getLayoutInflater(), viewGroup, null);
-            viewGroup.addView(view);
-        }
     }
 
     @Override

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -1010,17 +1010,6 @@ public class TimePickerDialog extends AppCompatDialogFragment implements
     }
 
     @Override
-    public void onConfigurationChanged(final Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        ViewGroup viewGroup = (ViewGroup) getView();
-        if (viewGroup != null) {
-            viewGroup.removeAllViewsInLayout();
-            View view = onCreateView(requireActivity().getLayoutInflater(), viewGroup, null);
-            viewGroup.addView(view);
-        }
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mHapticFeedbackController.start();


### PR DESCRIPTION
Hello!

I already wite my opinion about reasons of [bug #254 ](https://github.com/wdullaer/MaterialDateTimePicker/issues/254).

I think that removing `onConfigurationChanged()` methods is solving the problem, there is no info in docs about using this with `configChanges`. 
We no need to recreate view, with removing this part of code there is no memory leak and loosing state after rotation.

Tested these changes on Samsung galaxy S6 (7.0) and HTC 10 Lifestyle (7.0). 
Oneplus 8 (11.0) still no bug.